### PR TITLE
Fix: LICENSE was an unowned path, breaking the surface check on main

### DIFF
--- a/docs/AGENT-SURFACES.md
+++ b/docs/AGENT-SURFACES.md
@@ -83,6 +83,7 @@ plugins/security/**
 ```
 
 ```surface:repo-meta
+LICENSE
 docs/**
 scripts/**
 .github/**

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -4,6 +4,14 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 
 fail=0
+
+# The surface guard reads `git ls-files`, so a new file that has not been staged is invisible to
+# it and the check passes locally then fails in CI. Warn rather than guess.
+untracked=$(git ls-files --others --exclude-standard 2>/dev/null | head -5)
+if [ -n "$untracked" ]; then
+  printf '\033[33mwarning: untracked files are not seen by the surface check — stage them first:\033[0m\n'
+  printf '%s\n' "$untracked" | sed 's/^/  /'
+fi
 run() {
   printf '\n\033[1m%s\033[0m\n' "$1"; shift
   if "$@"; then :; else fail=1; printf '  FAILED\n'; fi


### PR DESCRIPTION
**`main` is currently failing its own surface check.** This fixes it.

## What broke

`agent-guard check` requires every tracked path to have exactly one owner. `LICENSE` was added in #3 but never added to a surface, so it is owned by nobody:

```
Agent surfaces FAILED — 1 problem(s):
  ✗ unowned: 1 tracked path(s) belong to nobody, e.g. LICENSE
```

## Why it passed before merging

The guard reads `git ls-files`, which only reports **tracked** files. I ran the checks before staging `LICENSE`, so the guard could not see it — green locally, red once the commit made it tracked.

That is a genuinely misleading failure mode: the check appears to pass on exactly the change that breaks it.

## The fix

1. `LICENSE` added to the `repo-meta` surface.
2. `check-all.sh` now warns when untracked files are present, so the gap is visible instead of silent.

## Verified by reproducing all three states

```
clean clone           → Agent surfaces passed.        (no warning)
+ untracked file      → warning: untracked files are not seen by the surface check
                        Agent surfaces passed.
+ staged              → ✗ unowned: 1 tracked path(s) belong to nobody, e.g. NEWSKILL.md
```

The middle state is the one that previously gave false confidence.

## Note

`verify` will be red until 1 September — Actions minutes are exhausted, so no runner is allocated. `./scripts/check-all.sh` passes on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_