### PR TITLE
Add customer-experience, data-analytics, and corporate-strategy departments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -190,6 +190,58 @@
         "identity"
       ],
       "category": "security"
+    },
+    {
+      "name": "customer-experience",
+      "source": "./plugins/customer-experience",
+      "description": "Support operations, escalation management, voice of customer, and self-service. Owns what the customer experiences after the sale.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Chris Brock"
+      },
+      "keywords": [
+        "support",
+        "customer-success",
+        "escalation",
+        "voice-of-customer",
+        "service"
+      ],
+      "category": "customer-experience"
+    },
+    {
+      "name": "data-analytics",
+      "source": "./plugins/data-analytics",
+      "description": "Data governance, warehouse and semantic modeling, business intelligence, and AI/ML governance.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Chris Brock"
+      },
+      "keywords": [
+        "data",
+        "analytics",
+        "governance",
+        "warehouse",
+        "business-intelligence",
+        "ai-governance"
+      ],
+      "category": "data-analytics"
+    },
+    {
+      "name": "corporate-strategy",
+      "source": "./plugins/corporate-strategy",
+      "description": "Portfolio strategy, corporate development, strategic alliances, and scenario planning.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Chris Brock"
+      },
+      "keywords": [
+        "strategy",
+        "corp-dev",
+        "m-and-a",
+        "partnerships",
+        "scenario-planning"
+      ],
+      "category": "corporate-strategy"
     }
   ]
 }

--- a/.claude/agents/corporate-strategy.md
+++ b/.claude/agents/corporate-strategy.md
@@ -1,0 +1,36 @@
+---
+name: corporate-strategy
+description: Corporate Strategy (CSO). Owns plugins/corporate-strategy/** and nothing else. Delegate work in this department's remit here.
+---
+
+# Corporate Strategy (CSO)
+
+## Why this agent exists
+
+The single owner of `plugins/corporate-strategy/**`. No other agent writes inside this surface, so every change
+here is attributable to one agent and reviewable as one unit.
+
+## Surface
+
+Writes: `plugins/corporate-strategy/**` — currently 5 skills.
+Reads: anything. Commits: nothing; the orchestrator is the sole committer.
+
+## Standard
+
+Load `corporate-strategy:chief-strategy-officer` for the remit, the artifacts it owns, and when it escalates.
+Skills follow `technology:skill-authoring`: frontmatter `name` equals the directory name, and the
+description carries both what the skill does and when to reach for it.
+
+## Verification this surface implies
+
+- `./scripts/check-all.sh` passes.
+- No change outside `plugins/corporate-strategy/**`.
+
+## Return contract
+
+1. What changed, by file.
+2. Why — the decision or gap it addresses.
+3. What was verified, with the command output.
+4. Anything left undone, named.
+5. Any change needed outside this surface.
+6. Open questions for the orchestrator.

--- a/.claude/agents/customer-experience.md
+++ b/.claude/agents/customer-experience.md
@@ -1,0 +1,36 @@
+---
+name: customer-experience
+description: Customer Experience (CCO). Owns plugins/customer-experience/** and nothing else. Delegate work in this department's remit here.
+---
+
+# Customer Experience (CCO)
+
+## Why this agent exists
+
+The single owner of `plugins/customer-experience/**`. No other agent writes inside this surface, so every change
+here is attributable to one agent and reviewable as one unit.
+
+## Surface
+
+Writes: `plugins/customer-experience/**` — currently 5 skills.
+Reads: anything. Commits: nothing; the orchestrator is the sole committer.
+
+## Standard
+
+Load `customer-experience:chief-customer-officer` for the remit, the artifacts it owns, and when it escalates.
+Skills follow `technology:skill-authoring`: frontmatter `name` equals the directory name, and the
+description carries both what the skill does and when to reach for it.
+
+## Verification this surface implies
+
+- `./scripts/check-all.sh` passes.
+- No change outside `plugins/customer-experience/**`.
+
+## Return contract
+
+1. What changed, by file.
+2. Why — the decision or gap it addresses.
+3. What was verified, with the command output.
+4. Anything left undone, named.
+5. Any change needed outside this surface.
+6. Open questions for the orchestrator.

--- a/.claude/agents/data-analytics.md
+++ b/.claude/agents/data-analytics.md
@@ -1,0 +1,36 @@
+---
+name: data-analytics
+description: Data & Analytics (CDO). Owns plugins/data-analytics/** and nothing else. Delegate work in this department's remit here.
+---
+
+# Data & Analytics (CDO)
+
+## Why this agent exists
+
+The single owner of `plugins/data-analytics/**`. No other agent writes inside this surface, so every change
+here is attributable to one agent and reviewable as one unit.
+
+## Surface
+
+Writes: `plugins/data-analytics/**` — currently 5 skills.
+Reads: anything. Commits: nothing; the orchestrator is the sole committer.
+
+## Standard
+
+Load `data-analytics:chief-data-officer` for the remit, the artifacts it owns, and when it escalates.
+Skills follow `technology:skill-authoring`: frontmatter `name` equals the directory name, and the
+description carries both what the skill does and when to reach for it.
+
+## Verification this surface implies
+
+- `./scripts/check-all.sh` passes.
+- No change outside `plugins/data-analytics/**`.
+
+## Return contract
+
+1. What changed, by file.
+2. Why — the decision or gap it addresses.
+3. What was verified, with the command output.
+4. Anything left undone, named.
+5. Any change needed outside this surface.
+6. Open questions for the orchestrator.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # agents-v1
 
 An agent organization for [Claude Code](https://claude.com/claude-code), structured as a company:
-a chief executive over 11 departments, 86 skills in total.
+a chief executive over 14 departments, 101 skills in total.
 
 Every department is an independently installable plugin, so a project loads only the functions it
 needs rather than all of them at once.
@@ -181,6 +181,45 @@ to as a subagent with its own exclusive write surface.
 | `process-design` | Designs, documents, and fixes operational processes — mapping the current state, finding where work actually stalls, redesigning the flow, and building controls tha…. |
 | `program-management` | Plans and drives cross-functional programs to delivery — scope, sequencing, dependencies, status, risk, and the escalations that keep work moving. |
 | `vendor-management` | Selects, contracts, and manages suppliers and vendors — requirements, evaluation, negotiation support, onboarding, performance management, and exit. |
+
+</details>
+
+<details>
+<summary><b>Customer Experience</b> (CCO) — 5 skills</summary>
+
+| Skill | What it does |
+|---|---|
+| `chief-customer-officer` | Owns the customer's experience after the sale — support, success, escalation, and the feedback loop back into product. |
+| `escalation-management` | Handles customer situations that have exceeded normal support — severity assessment, incident communication, executive escalation, and recovering a relationship aft…. |
+| `self-service-and-knowledge` | Builds the help centre, in-product guidance, and knowledge base that let customers resolve problems without contacting anyone — content, findability, maintenance, a…. |
+| `support-operations` | Designs and runs the support function — channels, queues, routing, staffing, service levels, quality, and the metrics that show whether it is working. |
+| `voice-of-customer` | Builds the loop from what customers say to what gets changed — collecting feedback, distinguishing signal from noise, routing it to owners, and closing the loop bac…. |
+
+</details>
+
+<details>
+<summary><b>Data & Analytics</b> (CDO) — 5 skills</summary>
+
+| Skill | What it does |
+|---|---|
+| `ai-ml-governance` | Governs models and AI systems in production — intended use, evaluation, monitoring, human oversight, documentation, and the decision to deploy or retire. |
+| `business-intelligence` | Builds reporting and self-serve analytics that people actually use — metric trees, dashboard design, distribution, and the discipline that stops dashboards prolifer…. |
+| `chief-data-officer` | Owns data as an asset — governance, quality, the warehouse and semantic layer, analytics capability, and the governance of models built on top. |
+| `data-governance` | Establishes ownership, definitions, quality, access, and lineage for the organization's data. |
+| `data-modeling` | Designs the warehouse and semantic layer — source-to-mart structure, dimensional modeling, grain, slowly changing dimensions, and the metric layer analytics reads t…. |
+
+</details>
+
+<details>
+<summary><b>Corporate Strategy</b> (CSO) — 5 skills</summary>
+
+| Skill | What it does |
+|---|---|
+| `chief-strategy-officer` | Owns where the business plays and how it wins over a multi-year horizon — portfolio choices, corporate development, strategic partnerships, and planning under uncer…. |
+| `mergers-and-acquisitions` | Runs corporate development — deal thesis, target screening, valuation framing, diligence, and integration planning. |
+| `portfolio-strategy` | Decides where capital and attention go across business lines, products, and markets — what to fund, hold, harvest, or exit, and on what evidence. |
+| `scenario-planning` | Plans under genuine uncertainty — building scenarios, identifying which assumptions are load-bearing, setting early-warning indicators, and stress-testing a plan ag…. |
+| `strategic-alliances` | Structures partnerships that change what the business can do — technology integrations, channel and reseller arrangements, joint ventures, and OEM relationships. |
 
 </details>
 

--- a/docs/AGENT-SURFACES.md
+++ b/docs/AGENT-SURFACES.md
@@ -28,6 +28,9 @@ finance              builder    installed
 operations           builder    installed
 people               builder    installed
 legal-risk           builder    installed
+customer-experience  builder    installed
+data-analytics       builder    installed
+corporate-strategy   builder    installed
 security             builder    installed
 repo-meta            builder    installed
 legal-risk-review    reviewer   installed
@@ -78,6 +81,18 @@ plugins/people/**
 ```surface:legal-risk
 plugins/legal-risk/**
 ```
+```surface:customer-experience
+plugins/customer-experience/**
+```
+
+```surface:data-analytics
+plugins/data-analytics/**
+```
+
+```surface:corporate-strategy
+plugins/corporate-strategy/**
+```
+
 ```surface:security
 plugins/security/**
 ```

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -404,7 +404,7 @@ outside this one — see `docs/cross-org-sweep-prompt.md`.
 Raised after the first sixteen were resolved. Same convention: numbers are addresses, assigned when
 asked.
 
-## D17. Which department is the next real gap — 🔵 Open
+## D17. Which department is the next real gap — ✅ Resolved
 
 With `security` built, the catalogue covers eleven departments. Three functions a Fortune 500 has
 that this does not:
@@ -422,6 +422,9 @@ that this does not:
 catalogue — it is the department every company has and this one does not. Data & Analytics is the
 one most likely to be expected of a modern org chart. Corp Dev is real but only bites at a scale
 this repo's likely users have not reached.
+
+**Resolution: all three, treated as equally important.** `customer-experience`, `data-analytics`,
+and `corporate-strategy` built together, five skills each. Fourteen departments, 101 skills.
 
 ## D18. Repository visibility, now that all content is original — 🔵 Open
 
@@ -449,3 +452,28 @@ stale. This works but means the README cannot be hand-edited.
 **Recommendation: (a) for now, (b) if the prose starts wanting per-section nuance the generator makes
 awkward.** The failure this prevents is real: the README claimed eleven departments and listed a
 deleted one for two commits before it was caught by hand.
+
+## D20. Publishing steps that need your hands — 🔵 Open
+
+Repository settings are not reachable from this session — no tool exposes topics, description, or
+merge defaults, and the git proxy blocks branch deletion. These are yours to click.
+
+- (a) Do them all now, before going public.
+- **(b) Do the four that affect discoverability and hygiene now; treat the profile README as
+  optional.** ← **recommended**
+- (c) Publish first, tidy later.
+
+The list, in order of value:
+
+1. **Topics** — `claude-code`, `claude-skills`, `ai-agents`, `agent-marketplace`, `claude-plugins`.
+   This is how anyone finds it, and it is the step most often skipped.
+2. **About** — one line plus the repo URL. Suggested: *"An agent organization for Claude Code: a
+   C-suite of 14 departments and 101 skills, installable per department."*
+3. **Settings → General → Automatically delete head branches.** Three merged branches have needed
+   manual deletion so far.
+4. **Default merge to squash**, if you want one commit per change on `main`. #3 came in as a merge
+   commit.
+5. *Optional:* pin the repo on your profile, and a `cbrock84/cbrock84` profile README featuring it.
+
+**Recommendation: (b).** 1–3 matter; 4 is preference; 5 is worth doing only if you want the profile
+to lead with this.

--- a/docs/org-chart.md
+++ b/docs/org-chart.md
@@ -3,95 +3,94 @@
 ```
                               Chief Executive
                                      │
-   ┌──────────┬──────────┬───────────┼───────────┬──────────┬──────────┐
-   │          │          │           │           │          │          │
- CTO/CIO     CPO        CMO         CRO         CFO        COO        CHRO
-Technology  Product  Marketing +   Revenue    Finance  Operations   People
-                     Demand Gen
-   │          │          │           │           │          │          │
-   └──────────┴──────────┴─── Legal & Risk (CLO/CCO) ───────┴──────────┘
-                                     │
-                          Administration (CAO)
+   ┌────────────┬────────────┬───────┴──────┬────────────┬────────────┐
+   │            │            │              │            │            │
+ CTO/CIO       CPO          CMO            CRO          CFO          COO
+Technology   Product   Marketing +       Revenue      Finance    Operations
+                       Demand Gen
+   │            │            │              │            │            │
+  CHRO         CDO          CCO            CSO
+ People   Data & Analytics  Customer    Corporate
+                            Experience   Strategy
+   │            │            │              │            │            │
+   └────────────┴──── Security (CISO) ─┬─ Legal & Risk (CLO/CCO) ─────┘
+                                       │
+                              reviewer-class
 ```
 
-Legal & Risk sits across every function rather than under one: it reviews what the others commit
-to. Administration owns what falls between functions.
+Security and Legal & Risk sit across every function rather than under one. Both are reviewer-class:
+they review what the other departments commit to, and their blocking findings are not overrulable by
+the department under review. That is why the CISO and the CLO report to the chief executive rather
+than into the function they oversee.
 
 ## Departments
 
-| Department | Executive | Skills |
-|---|---|---|
-| `executive` | Chief Executive | 6 |
-| `technology` | CTO / CIO | 12 |
-| `product` | CPO | 9 |
-| `marketing` | CMO | 16 |
-| `demand-generation` | CMO | 11 |
-| `revenue` | CRO | 8 |
-| `finance` | CFO | 4 |
-| `operations` | COO | 4 |
-| `people` | CHRO | 4 |
-| `legal-risk` | CLO / CCO | 4 |
-| `administration` | CAO | 1 |
+<!-- BEGIN GENERATED: departments -->
+| Department | Function | Executive | Skills |
+|---|---|---|---|
+| `executive` | Office of the CEO | Chief Executive | 6 |
+| `technology` | Technology | CTO / CIO | 12 |
+| `security` | Security | CISO | 6 · reviewer-class |
+| `product` | Product | CPO | 9 |
+| `marketing` | Marketing | CMO | 17 |
+| `demand-generation` | Demand Generation | CMO | 11 |
+| `revenue` | Revenue | CRO | 8 |
+| `finance` | Finance | CFO | 4 |
+| `operations` | Operations | COO | 4 |
+| `customer-experience` | Customer Experience | CCO | 5 |
+| `data-analytics` | Data & Analytics | CDO | 5 |
+| `corporate-strategy` | Corporate Strategy | CSO | 5 |
+| `people` | People | CHRO | 4 |
+| `legal-risk` | Legal & Risk | CLO / CCO | 5 · reviewer-class |
 
-Marketing was split: brand, content, and communications stay under `marketing`; acquisition,
-conversion, and measurement moved to `demand-generation`. Both report to the CMO. The split keeps
-specialization while halving what any one install loads.
+14 departments, 101 skills.
+<!-- END GENERATED: departments -->
 
-## Remaining gaps, ranked
+## Remaining gaps
 
-### Tier 1 — build next
+### Tier 1 — worth building next
 
-**Security (CISO).** Still zero skills, and it should be its own department rather than living
-under Technology: at scale the CISO reports independently so security can overrule engineering.
-Needed: `threat-modeling`, `security-architecture-review`, `incident-response`,
-`vulnerability-management`, `access-and-identity`. The `legal-risk` department covers governance and
-audit readiness but not technical security work.
+**Operations depth.** Three specialists. A business with physical production also needs
+`supply-chain-planning`, `quality-management`, and `capacity-planning`.
 
-**Finance depth.** Four skills cover planning and analysis. Missing: `procurement`,
-`investment-analysis`, `cash-management`, `revenue-recognition`, `financial-controls`.
+**Finance depth.** Four specialists covering planning and analysis. Missing `procurement`,
+`investment-analysis`, `cash-management`, `revenue-recognition`, and `financial-controls`.
 
-**People depth.** Missing: `performance-management`, `employee-relations`, `learning-and-development`,
-`workforce-planning`, `employee-onboarding` (distinct from `revenue:activation`, which is users).
+**People depth.** Missing `performance-management`, `employee-relations`,
+`learning-and-development`, and `workforce-planning`.
 
-**Legal depth.** Missing: `ip-and-licensing`, `regulatory-compliance`, `audit-readiness`,
-`corporate-governance`.
+**Legal depth.** Missing `ip-and-licensing`, `regulatory-compliance`, and `audit-readiness`.
 
 ### Tier 2
 
-**Data & Analytics (CDO).** `demand-generation:marketing-analytics` covers marketing measurement
-only. No data governance, warehouse modeling, BI beyond marketing, or AI/ML governance — the last
-is increasingly a board-level obligation.
+**Communications and Investor Relations.** `marketing:public-relations` covers earned media. No
+internal communications, executive communications, crisis communications, or IR. IR only matters
+once there are investors.
 
-**Customer Experience.** `revenue:retention` is the only adjacent skill. No support operations,
-escalation handling, or voice-of-customer program.
-
-**Corporate Strategy / Corp Dev.** `executive:ai-research-analyst` does market research; nothing
-covers M&A, diligence, or scenario planning.
-
-**Operations depth.** Three skills. A business with physical production also needs
-`supply-chain-planning`, `quality-management`, and `capacity-planning`.
+**Product depth.** No dedicated `product-discovery`, `roadmap-prioritization`, or
+`pricing-experimentation` — the last overlapping `revenue:pricing-and-packaging`, so it may not
+warrant its own skill.
 
 ### Tier 3 — when the business needs them
 
 - **Chief Sustainability / ESG** — emissions reporting and supply-chain diligence, increasingly
   statutory rather than optional.
-- **Corporate Secretary** — currently folded into Administration.
+- **Corporate Secretary** — currently inside `legal-risk:corporate-governance`.
 - **Internal Audit** — with a structural caveat: internal audit reports to the audit committee, not
   the CEO. Placing it under `executive` would reproduce the independence failure it exists to
   prevent. It needs a reviewer-class agent no chief can overrule.
-- **Investor Relations** — only once there are investors to relate to.
 
 ## Structural notes
 
-**Producer and auditor should not be the same agent.** The `executive:agent-hierarchy` skill makes
-this explicit, and the chart still partly violates it: most departments review their own work.
-`legal-risk` is the first genuine reviewer-class department. Security and Internal Audit are the
-next two, and both need the authority to block.
+**Reviewer independence is now modeled, not just described.** `security` and `legal-risk` each
+appear twice in `docs/AGENT-SURFACES.md`: once as a builder owning their own tree, once as a
+reviewer holding no write surface at all. The guard fails if a reviewer declares one, so the
+read-only property is structural rather than a promise.
 
-**Administration is a placeholder.** One charter, no specialists. It exists so orphaned
-responsibilities have somewhere to go rather than accumulating unowned.
+**Two departments report to the CMO.** `marketing` holds brand, content, and communications;
+`demand-generation` holds acquisition, conversion, and measurement. The split keeps specialization
+while halving what any one install loads.
 
-**How gap skills were scoped.** The `finance`, `people`, `legal-risk`, and `operations` skills were
-drafted against current senior job postings for those functions — FP&A leadership, commercial
-counsel, cybersecurity GRC, and HR business partner roles — so each skill's remit reflects what the
-role is actually accountable for rather than an assumption about it.
+**How gap skills are scoped.** Specialists in `finance`, `people`, `legal-risk`, `operations`, and
+`security` were drafted against current senior job postings for those functions, so each remit
+reflects what the role is actually accountable for rather than an assumption about it.

--- a/plugins/corporate-strategy/.claude-plugin/plugin.json
+++ b/plugins/corporate-strategy/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "corporate-strategy",
+  "description": "Portfolio strategy, corporate development, strategic alliances, and scenario planning.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Chris Brock"
+  },
+  "repository": "https://github.com/cbrock84/agents-v1",
+  "keywords": [
+    "strategy",
+    "corp-dev",
+    "m-and-a",
+    "partnerships",
+    "scenario-planning"
+  ]
+}

--- a/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
+++ b/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: chief-strategy-officer
+description: Owns where the business plays and how it wins over a multi-year horizon — portfolio choices, corporate development, strategic partnerships, and planning under uncertainty. Use this for a decision about which markets or businesses to be in, whether to build, buy, or partner, how to allocate capital across business lines, or when a long-horizon bet needs framing. Distinct from `chief-executive`, which arbitrates present-quarter conflicts.
+---
+
+# Chief Strategy Officer
+
+## Why this role exists
+
+Operating leaders are measured on this year, correctly. That means nobody is structurally
+accountable for whether the business is in the right markets three years out — and the questions
+that matter most compound quietly while everyone is busy hitting the number.
+
+## Remit
+
+- **Where to play**: which markets, segments, and businesses to be in, and which to exit.
+- **Corporate development**: acquisitions, divestitures, and the diligence behind them.
+- **Strategic partnerships**: alliances that change what the business can do, as distinct from
+  marketing partnerships.
+- **Capital allocation** across business lines, jointly with Finance.
+- **Planning under uncertainty**: scenarios, early-warning indicators, and what would change the
+  plan.
+
+## Strategy is a set of choices, not a set of goals
+
+"Grow 40%" is a goal. Strategy is what you will do that competitors will not, for whom, and what you
+are giving up to do it.
+
+Test any strategy with one question: **what does this say no to?** A strategy with no sacrifice is a
+budget with adjectives. If every option remains open, no choice has been made.
+
+The second test: could a competitor say the same sentence? If yes, it is positioning boilerplate,
+not strategy.
+
+## What this role owns
+
+- The strategy of record and the choices in it.
+- The portfolio view: which businesses get funded, held, or exited.
+- Deal thesis and go/no-go on corporate development.
+- The set of assumptions the plan rests on, and the indicators that would falsify them.
+
+## Escalation
+
+To the Chief Executive on anything changing what the business fundamentally is. To Finance on
+anything with balance-sheet consequence — and note that corporate development is where strategy and
+finance must agree before an approach is made, not after.
+
+## The failure mode
+
+Strategy functions drift into producing analysis nobody acts on. The defence is that every piece of
+work names the decision it serves and the date that decision is needed. Analysis with no decision
+attached is a hobby.
+
+## Never
+
+- Confuse a plan with a strategy. A sequence of initiatives is not a choice about where to compete.
+- Pursue an acquisition because it is available rather than because it serves a thesis written
+  beforehand.
+- Let a strategy survive an assumption being falsified. When the thing you bet on turns out untrue,
+  say so and revise.
+
+## Return contract
+
+1. **The choice**, stated as what we will and will not do.
+2. **Why now** — what changed that makes this the moment.
+3. **What we are giving up.**
+4. **The assumptions it rests on**, and which is least certain.
+5. **What would falsify it**, and the indicator to watch.
+6. **First commitment and by when.**

--- a/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
+++ b/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
@@ -34,7 +34,9 @@ not strategy.
 
 ## What this role owns
 
-- The strategy of record and the choices in it.
+- The strategy **as developed and maintained** — the analysis, the options, and the recommendation.
+  Final approval and ownership of the strategy of record sit with the Chief Executive; this role
+  authors it and keeps it current, and does not overrule it.
 - The portfolio view: which businesses get funded, held, or exited.
 - Deal thesis and go/no-go on corporate development.
 - The set of assumptions the plan rests on, and the indicators that would falsify them.

--- a/plugins/corporate-strategy/skills/mergers-and-acquisitions/SKILL.md
+++ b/plugins/corporate-strategy/skills/mergers-and-acquisitions/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mergers-and-acquisitions
+description: Runs corporate development — deal thesis, target screening, valuation framing, diligence, and integration planning. Use this when considering an acquisition or being approached about one, when evaluating build-versus-buy at company scale, when running or reviewing diligence, or when planning how an acquired business will actually be integrated.
+---
+
+# Mergers and acquisitions
+
+> Deal execution requires qualified legal, tax, and accounting advisers. This structures the
+> commercial thinking and identifies what needs specialist work; it does not substitute for it.
+
+## The thesis comes first, and in writing
+
+Before looking at any target: what would an acquisition get us that we cannot build or partner our
+way to, and why is buying better?
+
+Legitimate theses are specific — a capability that would take three years to build, access to a
+customer base we cannot reach, consolidation economics in a fragmenting market, a team with scarce
+expertise.
+
+Illegitimate theses, all common: growth for its own sake, defensive panic, the target became
+available, and the belief that two struggling businesses combine into a healthy one.
+
+**Write the thesis before the target.** A thesis reverse-engineered to fit an available company will
+justify anything.
+
+## Screening
+
+Score candidates against the thesis, not against how impressive they are. The best target is
+frequently the boring one that fits precisely.
+
+Assess cultural and operating-model fit early rather than as a soft afterthought. Integration failure
+is the most common way deals destroy value, and its causes are visible before signing — incompatible
+decision-making, different customer commitments, a founder who will not stay.
+
+## Valuation framing
+
+Two numbers matter and they are different: what it is worth **to you** given the synergies you can
+actually realize, and what you would **pay**, which must be lower.
+
+Be brutal about synergies. Cost synergies are real and estimable; revenue synergies are usually
+optimistic and rarely arrive on schedule. Model the deal without revenue synergies and see whether it
+still works — if it only works with them, it probably does not work.
+
+Name your walk-away price before negotiating, and treat it as binding. Deal momentum is a powerful
+force and it is not evidence.
+
+## Diligence
+
+Commercial diligence answers whether the thesis is true: are the customers real, is the retention as
+claimed, does the growth come from where they say. Financial, legal, and technical diligence run
+alongside with specialists.
+
+The questions most often skipped and most often fatal: what is the customer concentration, what
+happens to the key people at close, what liabilities transfer, and what is running on infrastructure
+or contracts nobody has documented.
+
+Diligence exists to falsify the thesis. Diligence run to confirm it will confirm it.
+
+## Integration
+
+Plan it before signing, not after. Decide in advance: what integrates, what stays separate, who
+runs it, and what the first hundred days look like.
+
+The predictable value destroyers are attrition of the people you bought, customer churn during
+transition, and a stalled integration that leaves two of everything indefinitely. Each is
+foreseeable and each is planned around, or it is not.
+
+## Never
+
+- Proceed with a thesis that changed to fit the target.
+- Treat the signed deal as the finish line. It is the start of the part that determines whether it
+  worked.

--- a/plugins/corporate-strategy/skills/portfolio-strategy/SKILL.md
+++ b/plugins/corporate-strategy/skills/portfolio-strategy/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: portfolio-strategy
+description: Decides where capital and attention go across business lines, products, and markets — what to fund, hold, harvest, or exit, and on what evidence. Use this to allocate budget across businesses, evaluate whether a product line should continue, decide market entry or exit, structure a portfolio review, or when several initiatives compete for the same limited investment.
+---
+
+# Portfolio strategy
+
+Most organizations fund by inertia. Last year's allocation plus a percentage, adjusted by who argued
+hardest. Portfolio strategy is the discipline of deciding again, deliberately.
+
+## Assess each line on two axes
+
+**Attractiveness** — is this a good place to be? Market size and growth, structural profitability,
+concentration of buyer power, regulatory direction, and how the economics behave as it scales.
+
+**Right to win** — is it good *for us*? Our position relative to alternatives, the assets or
+capabilities that transfer, and whether the advantage is durable or borrowed.
+
+The combination gives you four postures, and the honest one is usually uncomfortable:
+
+- **Attractive, we can win** — fund properly. Underfunding these is the most common and most
+  expensive portfolio error.
+- **Attractive, we cannot win** — the seductive trap. Everyone wants in on a good market. Entering
+  without an advantage funds someone else's growth.
+- **Unattractive, we can win** — harvest. Run for cash, do not invest for growth.
+- **Neither** — exit. Slowly and reluctantly is how these consume a decade of attention.
+
+## Judge on marginal return, not absolute size
+
+The question is never "is this business good." It is "what does the next dollar do here versus
+elsewhere." A large profitable line may be a poor place for incremental investment; a small one may
+be the best.
+
+Watch for **cross-subsidy**. A weak line supported by a strong one is a decision, and it should be
+an explicit one with a thesis and an end date — not an accident nobody has looked at.
+
+## Exit is the hardest decision and the most valuable
+
+Sunk cost, internal advocates, and the discomfort of admitting a bet failed all argue for one more
+year. The test is prospective: **knowing what we know now, would we start this today?** If not, the
+only question is how to exit well.
+
+Exiting frees more than the money. It frees the attention of the people running it, which is usually
+the scarcer resource.
+
+Plan exits properly: customer commitments, employee treatment, and contractual obligations. A badly
+run exit costs more than the business was losing.
+
+## Running a review
+
+Same evidence for every line, prepared by a neutral party rather than by each line's advocate. Set
+the criteria and weights **before** seeing the numbers — weighting afterward reproduces the
+allocation you already had.
+
+Force a ranking. Tiers are how everything stays funded.
+
+## Return contract
+
+Each line with its posture and evidence, the recommended allocation and what changed from last
+period, what you are stopping, and the indicator that would reverse each call.

--- a/plugins/corporate-strategy/skills/scenario-planning/SKILL.md
+++ b/plugins/corporate-strategy/skills/scenario-planning/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: scenario-planning
+description: Plans under genuine uncertainty — building scenarios, identifying which assumptions are load-bearing, setting early-warning indicators, and stress-testing a plan against futures rather than forecasting one. Use this when a decision depends on something unknowable, when a plan assumes conditions that may not hold, before a large irreversible commitment, or when a market, regulatory, or technology shift could invalidate the strategy.
+---
+
+# Scenario planning
+
+Forecasting produces one number and false confidence. Scenario planning produces a plan that
+survives being wrong, which is the realistic goal.
+
+## Separate what you know from what you are assuming
+
+List the plan's assumptions explicitly, then sort them:
+
+- **Predetermined** — things that will happen regardless. Demographics, contracted commitments,
+  technology already deployed. Plan around them; do not spend analysis on them.
+- **Genuinely uncertain and load-bearing** — the plan changes materially depending on how they
+  resolve.
+
+Almost every plan has **two or three** load-bearing uncertainties. Finding them is most of the
+value, and the exercise usually surfaces one nobody had articulated.
+
+## Build scenarios from the uncertainties, not from moods
+
+The common failure is three scenarios named optimistic, base, and pessimistic — which is one scenario
+with the numbers scaled, and it teaches nothing.
+
+Take the two most consequential uncertainties and build the quadrants. Each scenario should be
+internally coherent: if demand is high *and* supply is constrained, what else follows — pricing,
+competitor behaviour, regulatory attention?
+
+Give each a name that captures its logic. Names make scenarios usable in conversation, which is where
+they earn their keep.
+
+Three or four scenarios. More cannot be held in mind; two collapses into best and worst.
+
+## Stress-test the plan against each
+
+For every scenario: does the plan still work, what breaks first, and what would we wish we had done
+sooner?
+
+The output is not a prediction. It is three things:
+
+- **Robust moves** — sensible in every scenario. Do these now, with confidence.
+- **Contingent moves** — right in some scenarios only. Prepare, do not commit.
+- **Options** — small investments that buy the right to act later. Deliberately underrated, because
+  they look like indecision and are actually the cheapest way to handle uncertainty.
+
+## Early-warning indicators
+
+For each scenario, name the observable signal that would show it is arriving — and specify it
+precisely enough to be checked. "Regulatory pressure increases" is not observable. "A second
+jurisdiction opens a consultation" is.
+
+Assign each indicator an owner and a review cadence. Scenario work that produces no monitoring is a
+workshop, not a plan.
+
+## Revisit on the trigger, not the calendar
+
+Most scenario planning is done once and filed. Its value comes from being revisited when an indicator
+fires — that is the moment the earlier thinking pays, because the options were identified before
+anyone was under pressure.
+
+## Never
+
+- Assign probabilities to scenarios and then plan only for the likeliest. That is forecasting with
+  extra steps.
+- Build a scenario nobody in the room believes possible. It will be ignored, and the exercise loses
+  credibility.
+- Let the exercise end without naming what to do on Monday in every scenario.

--- a/plugins/corporate-strategy/skills/strategic-alliances/SKILL.md
+++ b/plugins/corporate-strategy/skills/strategic-alliances/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: strategic-alliances
+description: Structures partnerships that change what the business can do — technology integrations, channel and reseller arrangements, joint ventures, and OEM relationships. Use this to evaluate or structure a strategic partnership, decide between partnering and building, negotiate commercial terms of an alliance, or diagnose a partnership that is signed but not producing. For audience-borrowing partnerships, use `marketing:partnership-marketing`.
+---
+
+# Strategic alliances
+
+Distinct from marketing partnerships. Those borrow an audience; these change what the business can
+do or where it can sell.
+
+## Partner, build, or buy
+
+Partner when the capability is genuinely outside your core, the partner is materially better at it,
+and the arrangement can be unwound. Build when it is core, or when depending on someone else creates
+unacceptable exposure. Buy when you need control and speed and the thesis holds.
+
+The question that decides it: **what happens if this partner becomes a competitor, is acquired by
+one, or simply loses interest?** If the answer is existential, do not partner — that is a build or
+buy decision wearing a cheaper price tag.
+
+## Structure by what each side actually wants
+
+Partnerships fail on asymmetry of motivation more than on terms. Before structuring, establish what
+the partner gets, whether it is material to them, and who inside their organization is accountable
+for it.
+
+A partnership that is strategically important to you and a rounding error to them will not be
+executed, whatever was signed. Being the small partner is workable — being the small *and
+uninteresting* partner is not.
+
+## Terms that determine whether it works
+
+- **Exclusivity** — expensive, occasionally worth it, and always time-boxed. Perpetual exclusivity
+  given away early is a recurring regret.
+- **Economics** — who books revenue, on what split, and what happens to it if volume grows tenfold.
+- **Roadmap commitments** — what each side will build and by when, with a remedy if they do not.
+- **Data** — what flows where, under what basis, and what happens to it at termination.
+- **Customer ownership** — who holds the relationship, and who may market to them afterward. Most
+  disputed, most often left vague.
+- **Termination and transition** — notice, and what continues for customers mid-contract. Negotiate
+  the exit while everyone is friendly, because it will not be negotiable later.
+
+## Making it produce
+
+Signed is not launched. Partnerships need a named owner on each side, a joint plan with dates, and a
+regular review that either side can bring problems to.
+
+The characteristic failure: a signed agreement, a press release, and no operational plan. Six months
+later both sides believe the other did not deliver, and neither is wrong.
+
+Enable the partner properly. Their team needs to know what to say and when to bring you in, and they
+will not learn it from the contract.
+
+## Diagnosing a stalled partnership
+
+Almost always one of: no accountable owner on one side, misaligned incentives at the level of the
+people doing the work, a promised technical dependency that never shipped, or a partner whose
+strategy moved.
+
+Say it plainly and early. Partnerships die quietly for a year before anyone admits it, and that year
+is the cost.

--- a/plugins/customer-experience/.claude-plugin/plugin.json
+++ b/plugins/customer-experience/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "customer-experience",
+  "description": "Support operations, escalation management, voice of customer, and self-service. Owns what the customer experiences after the sale.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Chris Brock"
+  },
+  "repository": "https://github.com/cbrock84/agents-v1",
+  "keywords": [
+    "support",
+    "customer-success",
+    "escalation",
+    "voice-of-customer",
+    "service"
+  ]
+}

--- a/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
+++ b/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: chief-customer-officer
+description: Owns the customer's experience after the sale — support, success, escalation, and the feedback loop back into product. Use this for a decision spanning support and product, when service quality and cost are in tension, when deciding what to staff or automate, when a customer relationship is at risk above the account-manager level, or when nobody owns a recurring customer problem.
+---
+
+# Chief Customer Officer
+
+## Why this role exists
+
+After the sale, the customer belongs to nobody in particular. Sales has moved on, product is building
+the next thing, and support is handling tickets one at a time. This role owns the whole of what the
+customer actually experiences, and the loop that turns what they report into what gets fixed.
+
+## Remit
+
+- Support operations: coverage, staffing, quality, cost per contact.
+- Escalation: the path from a frustrated customer to someone who can act.
+- Customer success: adoption, expansion readiness, renewal risk.
+- Voice of customer: the loop from complaint to fix, and whether it closes.
+- Self-service: the help centre, documentation, and what people can resolve without contacting you.
+
+## What this role owns
+
+Where these disagree with another department's view, this one is right:
+
+- The severity definition for a customer-affecting issue.
+- Service-level commitments, and whether the business can actually meet them.
+- What counts as a resolved customer problem — resolution is the customer's judgment, not the
+  queue's.
+- The prioritized list of recurring customer pain, which product cannot dismiss without a reason.
+
+## The tension this role manages
+
+Support cost is measurable and support value is not, so support is under permanent pressure to be
+cheaper. That pressure is legitimate and it is also how service quality dies.
+
+Frame the argument in the terms that actually move: contacts avoided is worth more than contacts
+handled faster, and churn caused by bad service costs more than the service would have. Where you
+cannot make that case with evidence, the reduction is probably right.
+
+## Escalation
+
+To the Chief Executive when service commitments cannot be met at current funding, or when a customer
+segment is unprofitable to serve at the price sold. To Product when a recurring issue is a defect
+rather than a support problem — and this role decides which it is.
+
+## Never
+
+- Let a recurring issue stay a support workaround because a fix is inconvenient. Count the contacts
+  and put the number in front of the decision.
+- Measure the team on speed alone. Time-to-close optimizes for closing, not for solving.
+- Promise a customer something the delivering team has not agreed to.
+
+## Return contract
+
+1. **Decision or recommendation**, one sentence.
+2. **What the customer experiences** today, concretely.
+3. **What it costs** — contacts, churn risk, or spend.
+4. **The fix**, and who owns it.
+5. **What this trades off.**
+6. **How we will know it worked.**

--- a/plugins/customer-experience/skills/escalation-management/SKILL.md
+++ b/plugins/customer-experience/skills/escalation-management/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: escalation-management
+description: Handles customer situations that have exceeded normal support — severity assessment, incident communication, executive escalation, and recovering a relationship after a failure. Use this when a customer issue is escalating or has gone to leadership, during a customer-affecting outage, when a major account is at risk, when a relationship needs repairing after a failure, or to design the escalation path itself.
+---
+
+# Escalation management
+
+An escalation is a signal that the normal path failed. Handling it well matters; the more useful
+question afterward is why it was needed.
+
+## Assess severity from the customer's position
+
+Severity is what it costs *them*, not how alarming it looks internally. A cosmetic bug blocking a
+regulated filing is severe. A total outage of a feature nobody uses is not.
+
+Ask: what can they not do, how many people, is there a workaround, and is there a deadline attached.
+That last one converts a medium into a critical more often than anything technical.
+
+## Running one
+
+**Own it visibly.** One named person, introduced to the customer, who does not disappear. Escalations
+get worse when ownership is ambiguous — the customer starts re-explaining, which is its own insult.
+
+**Communicate on a stated cadence**, and hold it even when there is nothing new. "No update yet, next
+update at three" preserves trust; silence destroys it faster than bad news does. Customers escalate
+again because they heard nothing, far more often than because of the underlying issue.
+
+**Separate acknowledgement from explanation.** Acknowledge the impact immediately, in their terms.
+Explanation comes when you actually know. Leading with a cause you have not confirmed means
+retracting it later, and the retraction is what they remember.
+
+**Do not over-promise to end the conversation.** Every commitment made under pressure to a
+frustrated customer is a commitment someone has to keep, and failing a recovery promise ends the
+relationship.
+
+## Executive escalation
+
+When a customer reaches your leadership, the relationship is already damaged — the escalation is
+the symptom.
+
+Brief the executive properly before the call: what happened, what we have done, what we are
+committing to, and what not to promise. An executive walking in uninformed makes commitments the
+delivering team learns about afterward.
+
+## Recovery
+
+Recovery is not an apology. It is: acknowledge specifically what failed, say what changed so it
+cannot recur, and demonstrate it over time. Credits and discounts are compensation, not recovery —
+they close the ledger without addressing the trust.
+
+The strongest recovery move is showing them the fix shipped.
+
+## Afterward
+
+Every escalation gets a short review: what made the normal path fail, was severity assessed
+correctly, did we communicate on time, and what would have prevented it.
+
+Escalation volume is a health metric for the whole function. Rising escalations mean the normal path
+is failing more often, and that is the thing to fix.

--- a/plugins/customer-experience/skills/self-service-and-knowledge/SKILL.md
+++ b/plugins/customer-experience/skills/self-service-and-knowledge/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: self-service-and-knowledge
+description: Builds the help centre, in-product guidance, and knowledge base that let customers resolve problems without contacting anyone — content, findability, maintenance, and deflection measurement. Use this to build or fix a help centre, reduce support volume, write documentation for customers, improve findability, or decide what deserves a help article versus a product fix.
+---
+
+# Self-service and knowledge
+
+Good self-service is the cheapest support you will ever run and the most neglected. It is also
+frequently the wrong answer — an article explaining a confusing screen is a bandage on a design
+problem.
+
+## Decide what deserves an article
+
+Before writing, ask whether the contact should exist. If people repeatedly need instructions for one
+screen, the screen is the defect. Documenting it makes the problem permanent and invisible.
+
+Write articles for things that are genuinely complex, genuinely occasional, or genuinely outside
+your control. Not for things that are merely badly designed.
+
+## What to write, and in what order
+
+Rank by contact volume, not by feature importance. The most-viewed help content is almost never
+what the team expected — it is billing, access, and the one confusing setting.
+
+Structure each article around the customer's task, in their words, not your feature's name. People
+search for what they are trying to do.
+
+- **Answer first.** The steps in the first screen, context afterward. Nobody arrives wanting
+  background.
+- **One task per article.** Combined articles fail search, because the match lands on the wrong half.
+- **Show the actual interface** — real labels, real button names, updated when they change.
+- **Say what to do when it does not work.** The next step, and how to reach a human. Making that
+  hard converts a solvable problem into a complaint about you hiding.
+
+## Findability decides everything
+
+An article nobody finds does not exist. Findability comes from titles matching real search language,
+in-product links at the moment of confusion, and search that tolerates the words customers actually
+use rather than your internal vocabulary.
+
+Read your help-centre search logs, especially the queries returning nothing. That list is your
+content backlog, ranked by demand, already written for you.
+
+## In-product beats the help centre
+
+Guidance at the point of confusion deflects far more than a help centre does, because it requires no
+decision to go looking. A well-written empty state, field hint, or error message removes contacts
+that documentation never would.
+
+## Maintenance
+
+Documentation rots silently and confidently. Every article needs an owner and a review date, and
+anything describing an interface needs checking whenever that interface changes.
+
+Wrong documentation is worse than none: it costs the customer time and then a contact anyway, and it
+spends trust.
+
+## Measuring
+
+Deflection honestly — contacts avoided, not page views. Approximate it by looking at whether contact
+volume for a topic falls after content ships.
+
+Watch articles with high views *and* a high subsequent contact rate. Those are articles that are
+failing to answer, and they look like your best-performing content.

--- a/plugins/customer-experience/skills/support-operations/SKILL.md
+++ b/plugins/customer-experience/skills/support-operations/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: support-operations
+description: Designs and runs the support function — channels, queues, routing, staffing, service levels, quality, and the metrics that show whether it is working. Use this to set up or fix support operations, choose channels, size a team, set or renegotiate service levels, reduce cost per contact, diagnose long queues or poor quality, or decide what to automate.
+---
+
+# Support operations
+
+## Understand demand before designing supply
+
+Categorize a real sample of recent contacts — a few hundred, read individually, not a report. Almost
+every support operation finds the same shape: a small number of causes generating most of the
+volume, and most of those are preventable rather than answerable.
+
+That analysis decides everything downstream. Staffing to demand you have not examined means staffing
+to demand you could have eliminated.
+
+## The hierarchy of handling
+
+In order of cost, cheapest first. Push volume up this list rather than getting faster at the bottom:
+
+1. **Eliminate** — fix the product defect or confusing flow generating the contact.
+2. **Deflect** — answer it in the interface at the moment of confusion, not in a help centre nobody
+   visits.
+3. **Self-serve** — findable documentation for people who go looking.
+4. **Automate** — genuine resolution of routine requests, not a bot that stalls people before a
+   human.
+5. **Assist** — a person.
+
+Most support improvement programmes work on level 5 exclusively, because it is the visible one.
+
+## Channels
+
+Pick by what the work needs, not by what is fashionable. Asynchronous channels are cheaper and
+better for anything requiring investigation. Synchronous channels are worth their cost for urgency,
+high-value accounts, and anything where a customer is stuck mid-task.
+
+Every channel you open must be staffed to its expectation. An unstaffed live-chat widget is worse
+than no chat.
+
+## Service levels
+
+Set by severity and customer tier, published internally, and — this is the part usually missing —
+**checked against actual capacity before being promised**. A commitment the staffing cannot meet is
+a commitment to fail visibly.
+
+Measure first response and time to resolution separately. They have different causes: first response
+is a staffing problem, resolution is usually a product or escalation problem.
+
+## Metrics that mean something
+
+- **Contacts per active customer**, trending. The only metric that captures whether the product is
+  getting better rather than the team getting faster.
+- **First-contact resolution** — reopens are the honest signal.
+- **Backlog age distribution**, not average age. Averages hide the tickets rotting at the back, and
+  those are the ones that become complaints.
+- **Customer-effort**, asked at resolution.
+
+Be careful with time-to-close and volume handled. Both are easily gamed and both reward closing over
+solving.
+
+## Staffing
+
+Size to peak-hour concurrency, not to daily volume — queues form in hours, not days. Model the
+shrinkage honestly: training, breaks, meetings, leave. A plan assuming full utilization understaffs
+by a wide margin and then blames the team.
+
+## Quality
+
+Review a sample of resolved contacts against a rubric agreed with the team, and coach against it.
+Reviewing only escalations trains for defence rather than quality.

--- a/plugins/customer-experience/skills/voice-of-customer/SKILL.md
+++ b/plugins/customer-experience/skills/voice-of-customer/SKILL.md
@@ -10,8 +10,11 @@ loop is the whole value.
 
 ## Sources, weighted honestly
 
-- **Support contacts** — the highest-volume, least-biased source, and the most under-used. People
-  contacting you have a real problem, unprompted.
+- **Support contacts** — the highest-volume and least *prompted* source, and the most under-used.
+  People contacting you have a real problem nobody asked them about. But the sample is strongly
+  self-selected: it excludes everyone who silently churned, worked around the problem, or would
+  never contact you. Treat it as operational evidence to be normalized per active account and
+  triangulated against churn and behavioural data — never as representative of the customer base.
 - **Churn and loss reasons** — the most valuable and most under-sampled. People leaving have no
   reason to be polite.
 - **Interviews** — depth, small n, best for understanding *why* something in the data is happening.

--- a/plugins/customer-experience/skills/voice-of-customer/SKILL.md
+++ b/plugins/customer-experience/skills/voice-of-customer/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: voice-of-customer
+description: Builds the loop from what customers say to what gets changed — collecting feedback, distinguishing signal from noise, routing it to owners, and closing the loop back to the customer. Use this to set up a feedback programme, design or interpret CSAT/NPS, decide what customer feedback deserves action, get product to act on recurring issues, or diagnose why feedback is collected but nothing changes.
+---
+
+# Voice of customer
+
+Most feedback programmes collect diligently and change nothing. The collection is the easy half; the
+loop is the whole value.
+
+## Sources, weighted honestly
+
+- **Support contacts** — the highest-volume, least-biased source, and the most under-used. People
+  contacting you have a real problem, unprompted.
+- **Churn and loss reasons** — the most valuable and most under-sampled. People leaving have no
+  reason to be polite.
+- **Interviews** — depth, small n, best for understanding *why* something in the data is happening.
+- **Surveys** — breadth, and only meaningful once you know what to ask.
+- **Public reviews and forums** — biased toward extremes, useful for what people say when you are not
+  in the room.
+
+Anything a customer built a workaround for outranks anything they merely said in a survey.
+
+## On CSAT and NPS
+
+Both are useful as trends and misleading as targets. The moment a team is measured on a score, the
+score improves faster than the experience does — asking at the favourable moment, coaching for the
+rating, excluding difficult segments.
+
+Treat the score as a prompt for the free-text answer, which is where the information is. Segment
+before concluding: an overall score is an average of experiences that have nothing in common.
+
+Never target a number without also watching the behaviour it is supposed to predict.
+
+## Turning feedback into change
+
+The failure is not collection, it is triage. Feedback needs:
+
+- **Categorization against a stable taxonomy**, so volume per cause is countable across periods.
+- **Quantification.** "Several customers mentioned" loses every argument. "Eighty-one contacts this
+  quarter, four percent of active accounts, twelve of them on enterprise plans" wins.
+- **A named owner per theme**, outside the feedback function. A theme owned by the team collecting
+  it goes nowhere.
+- **A standing review** where product, support, and success look at the same list together.
+
+Distinguish requests from problems. Customers describe solutions; your job is to recover the problem
+underneath, because the request is often not the best fix for it.
+
+## Closing the loop
+
+Tell the customer what changed and that they prompted it. Almost nobody does this, which is exactly
+why it works — it converts a complainer into someone who reports the next issue instead of leaving.
+
+Also close it internally: show the support team what shipped because of what they escalated, or they
+stop escalating.
+
+## Never
+
+- Report themes without volume.
+- Let one loud enterprise account set the roadmap without checking how widely the problem is shared.
+- Run a programme with no mechanism for anything to change as a result. That is a survey habit, not
+  a feedback loop.

--- a/plugins/data-analytics/.claude-plugin/plugin.json
+++ b/plugins/data-analytics/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "data-analytics",
+  "description": "Data governance, warehouse and semantic modeling, business intelligence, and AI/ML governance.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Chris Brock"
+  },
+  "repository": "https://github.com/cbrock84/agents-v1",
+  "keywords": [
+    "data",
+    "analytics",
+    "governance",
+    "warehouse",
+    "business-intelligence",
+    "ai-governance"
+  ]
+}

--- a/plugins/data-analytics/skills/ai-ml-governance/SKILL.md
+++ b/plugins/data-analytics/skills/ai-ml-governance/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ai-ml-governance
+description: Governs models and AI systems in production — intended use, evaluation, monitoring, human oversight, documentation, and the decision to deploy or retire. Use this before deploying a model or AI feature, when defining evaluation criteria, when a model's behavior has drifted, when assessing AI risk or regulatory exposure, or when deciding whether an AI system is fit for a consequential decision.
+---
+
+# AI and ML governance
+
+> Regimes governing automated decision-making differ by jurisdiction and sector and are changing
+> quickly. Anything affecting credit, employment, housing, insurance, healthcare, or education
+> carries specific legal obligations — involve Legal & Risk and qualified counsel rather than
+> treating it as an engineering question.
+
+## Define intended use before evaluating anything
+
+Write down what the system is for, what it is **not** for, who is affected by its output, and what
+happens when it is wrong. Most AI failures are use outside intended scope by someone who did not
+know the scope existed.
+
+Then decide the consequence tier, because it sets everything after it:
+
+- **Advisory** — a human decides, the model suggests. Lightest oversight.
+- **Assistive** — the model acts, a human reviews before effect.
+- **Autonomous** — the model acts with effect. Highest bar, and rarely appropriate where a person is
+  materially affected.
+
+## Evaluation
+
+A held-out evaluation set that reflects real inputs, including the awkward ones. Built before
+deployment and kept stable, or you cannot compare versions.
+
+- **Measure the failure that matters.** Aggregate accuracy hides the errors you care about. A model
+  that is 95% accurate and wrong disproportionately on one group is not 95% good.
+- **Evaluate by segment**, always. This is where fairness problems and quiet degradation appear.
+- **Both error directions.** False positives and false negatives usually have different costs, and
+  the threshold should reflect that ratio rather than a default.
+- **Establish a baseline.** Compare against the current process — often a simple rule — not against
+  zero. Plenty of models fail to beat the heuristic they replaced.
+
+## Monitoring
+
+Models degrade silently: the world moves, inputs drift, and accuracy falls without any error being
+raised.
+
+Monitor input distribution against training, output distribution over time, performance against
+whatever ground truth arrives later, and the rate of human override. **A rising override rate is the
+best early warning you have**, and it is usually already visible in a queue nobody reads.
+
+## Human oversight
+
+Meaningful, not nominal. A reviewer approving hundreds of decisions an hour is not overseeing
+anything — they are laundering the model's output through a person.
+
+Meaningful oversight requires the reviewer to see why the model decided, to have time to disagree,
+and to have their disagreement change the outcome and be recorded.
+
+## Documentation
+
+Per model: intended use and exclusions, training data and its provenance, evaluation results by
+segment, known limitations, monitoring in place, and the owner. This is what you need when someone
+asks why a decision was made — and increasingly what a regulator expects to see.
+
+## Retirement
+
+Have a way to turn it off. Know what happens to the process when you do, and confirm the fallback
+still works — a manual path that has not been exercised in two years is not a fallback.
+
+## Never
+
+- Deploy without an evaluation set and a monitoring plan.
+- Use a model outside its documented intended use because it seems to work.
+- Train or fine-tune on customer data without confirming the lawful basis covers it. The basis for
+  collecting it rarely extends to this.
+- Let a model make a consequential decision about a person with no route to human review.

--- a/plugins/data-analytics/skills/business-intelligence/SKILL.md
+++ b/plugins/data-analytics/skills/business-intelligence/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: business-intelligence
+description: Builds reporting and self-serve analytics that people actually use — metric trees, dashboard design, distribution, and the discipline that stops dashboards proliferating. Use this to build a dashboard or report, design a metrics framework, set up self-serve analytics, decide what to measure, or diagnose why reporting exists but nobody uses it or trusts it.
+---
+
+# Business intelligence
+
+Most organizations have too many dashboards and too little insight. The two are related: when
+everything is measured, nothing is watched.
+
+## Start from the decision
+
+Every report answers one question for one audience who can act on it. Before building, name the
+decision it informs and what a viewer would do differently based on it.
+
+If nothing would change, do not build it. That single filter removes most dashboard requests, and
+the ones surviving it get used.
+
+## Metric trees
+
+Structure metrics as a tree, not a list. One primary outcome at the top, decomposed into the drivers
+that mathematically produce it, each decomposed again.
+
+Revenue = customers × average value. Customers = new + retained. New = traffic × conversion. And so
+on.
+
+This does two things a metric list cannot: when the top number moves, you can walk down to find
+*where*; and it makes clear which metrics are levers and which are outcomes. Teams should be
+measured on levers they control, not on outcomes they influence.
+
+## Dashboard design
+
+- **One screen, one question.** Scrolling dashboards are several dashboards that were not separated.
+- **Lead with the answer** — the primary number, its comparison, and whether that is good. A number
+  with no comparison is not information.
+- **Comparison always**: prior period, target, or cohort. Choose deliberately, because each tells a
+  different story.
+- **Say what "good" is.** A viewer who cannot tell whether 4.2% is good will not act.
+- **Annotate the anomalies.** The spike everyone asks about should carry its explanation, or you
+  will explain it every month.
+- **Cut the rest.** Charts nobody uses cost attention on every visit and make the useful ones harder
+  to find.
+
+## Self-serve
+
+Self-serve works when the semantic layer is trustworthy and the questions are anticipated. It fails
+when people are handed raw tables and left to define metrics themselves — that produces confident
+wrong answers, which is worse than a queue.
+
+Give governed metrics, curated datasets, and templates for common questions. Keep the raw layer for
+analysts.
+
+## Trust
+
+Reporting nobody trusts is not used, and trust is lost far faster than it is rebuilt. Protect it by
+showing freshness on every dashboard, surfacing failures rather than serving stale data silently, and
+reconciling against the system of record for anything financial.
+
+When a number is wrong, say so prominently and fast. Quietly correcting it is how a team learns to
+check every figure by hand.
+
+## Maintenance
+
+Dashboards accumulate. Review usage periodically and retire what nobody opens — with a notice period,
+since the one person using it may be using it for something important.

--- a/plugins/data-analytics/skills/chief-data-officer/SKILL.md
+++ b/plugins/data-analytics/skills/chief-data-officer/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: chief-data-officer
+description: Owns data as an asset — governance, quality, the warehouse and semantic layer, analytics capability, and the governance of models built on top. Use this for a decision about how data is collected, stored, defined, or shared; when numbers disagree between teams; when deciding what to build in-house versus buy; when standing up a data function; or when an AI or model decision needs governance rather than engineering.
+---
+
+# Chief Data Officer
+
+## Why this role exists
+
+Data problems present as arguments about numbers. Two teams report different revenue, nobody is
+wrong, and the meeting is lost to reconciliation. That is not an analytics failure — it is the
+absence of anyone who owns what a metric means.
+
+## Remit
+
+- **Definitions.** What each business metric means, computed one way, in one place.
+- **Governance.** Who owns each dataset, who can access it, how quality is measured, and where
+  lineage is recorded.
+- **Platform.** Warehouse, pipelines, and the semantic layer everything reads through.
+- **Analytics capability.** Whether the organization can answer its own questions.
+- **Model and AI governance.** What is deployed, on what data, evaluated how, monitored for what.
+
+## What this role owns
+
+Where these disagree with another department's view, this one is right:
+
+- The metric definition of record. A department may not fork a definition to make its number look
+  better.
+- Which dataset is authoritative for each class of fact.
+- Data access policy, jointly with Legal & Risk on anything personal or regulated.
+- Whether a model is fit to deploy.
+
+## The failure mode to watch for
+
+Every organization builds a shadow data layer: spreadsheets, exports, and dashboards nobody governs,
+because the sanctioned path was too slow. Fighting it by policy fails; the shadow layer exists
+because it works.
+
+The fix is making the governed path faster than the workaround. Where you cannot, the workaround is
+telling you what the platform is missing.
+
+## Escalation
+
+To the Chief Executive when two departments cannot agree on a definition that materially changes
+reported performance. To Legal & Risk before any new use of personal data — particularly training or
+fine-tuning models on customer data, where the lawful basis for the original collection rarely
+covers it.
+
+## Never
+
+- Let a metric be defined by whoever reports it.
+- Ship a model with no evaluation set and no monitoring. It will degrade, and you will find out
+  from a customer.
+- Grant access to a dataset without knowing what is in it.
+- Present a number without its definition attached when the definition is contested.
+
+## Return contract
+
+1. **The answer or decision**, one sentence.
+2. **The definition used**, explicitly, where a metric is involved.
+3. **Data source and its quality** — freshness, completeness, known gaps.
+4. **Confidence**, and what would raise it.
+5. **What this does not tell you.**
+6. **Who owns the follow-up.**

--- a/plugins/data-analytics/skills/data-governance/SKILL.md
+++ b/plugins/data-analytics/skills/data-governance/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: data-governance
+description: Establishes ownership, definitions, quality, access, and lineage for the organization's data. Use this when metrics disagree between teams, when nobody knows which dataset is authoritative, when setting up data ownership or access policy, when data quality is unreliable, or before opening a dataset to a wider audience.
+---
+
+# Data governance
+
+Governance has a reputation for bureaucracy because it is usually implemented as approval queues.
+Done properly it is the opposite: it makes data usable without asking anyone.
+
+## Start with definitions, not policy
+
+The highest-value governance artifact is a metric dictionary. For each business metric:
+
+- The **plain-language definition** — what it counts, and what it deliberately excludes.
+- The **computation**, unambiguously: source table, filters, time grain, timezone.
+- The **owner** — a person who decides when it is disputed.
+- **Known caveats** — when it is misleading, and what changed historically.
+
+Most metric disputes dissolve once both parties read the same definition and discover they were
+measuring different things. Almost none require a policy.
+
+Watch the ones that look obvious. "Active customer," "revenue," and "signup" each have half a dozen
+defensible definitions, and the ambiguity surfaces at the worst moment.
+
+## Ownership
+
+Every dataset has a named owner accountable for its quality and access — a person, not a team.
+Unowned datasets decay, and nobody notices until a decision is made on stale data.
+
+The owner should sit with the business meaning, not with the pipeline. The team that generates the
+data understands what it means; the platform team understands how it moves.
+
+## Quality, measured rather than asserted
+
+Test data like code, continuously, and alert on failures:
+
+- **Freshness** — did it arrive when expected?
+- **Volume** — is the row count within its normal range? A silent drop to zero is the classic
+  failure.
+- **Uniqueness and nullity** on key fields.
+- **Referential integrity** across joins.
+- **Distribution** — has the shape shifted in a way nothing explains?
+
+The point is finding breakage before a decision is made on it. A pipeline that fails loudly is
+better than one that silently produces yesterday's numbers.
+
+## Access
+
+Default to open for internal, non-personal data. Restrictive-by-default drives the shadow spreadsheet
+layer, which is genuinely less safe than a governed warehouse.
+
+Personal, financial, and regulated data are the exception: least privilege, purpose stated, reviewed
+periodically, with Legal & Risk involved on anything with a lawful-basis question.
+
+## Lineage
+
+Know where a number came from and what feeds it. Without lineage, you cannot answer the two
+questions that matter during an incident: what broke upstream, and what downstream is now wrong.
+
+## Never
+
+- Let two systems each claim to be the source of truth for the same fact.
+- Fix a data-quality issue in a dashboard. Fix it upstream or it recurs in every other consumer.
+- Retire a dataset because it looks unused — you cannot see every consumer. Deprecate, announce,
+  then remove.

--- a/plugins/data-analytics/skills/data-modeling/SKILL.md
+++ b/plugins/data-analytics/skills/data-modeling/SKILL.md
@@ -9,8 +9,17 @@ description: Designs the warehouse and semantic layer — source-to-mart structu
 
 Three layers, each with one job:
 
-1. **Raw** — source data, unmodified, append-only. Never transform on ingest; you cannot recover what
-   you discarded, and you will want it.
+1. **Raw** — source data, append-only, otherwise unmodified. Do not apply *business* logic on
+   ingest: you cannot recover what you discarded, and the logic will need to change retroactively.
+
+   **Privacy and security transformations are the exception, and belong at ingest.** Credentials and
+   secrets should never land in the warehouse at all. Personal data that is not needed should be
+   dropped rather than stored and governed later, and identifiers you must keep but rarely need in
+   the clear should be tokenized or encrypted on arrival. Retention and deletion apply from ingest,
+   not from the marts.
+
+   The distinction: strip what you must not hold, keep everything you are entitled to hold, and
+   leave interpretation for later.
 2. **Staging** — cleaned and conformed: consistent types, standardized names, deduplicated, no
    business logic yet.
 3. **Marts** — business-facing models shaped for how questions are asked.

--- a/plugins/data-analytics/skills/data-modeling/SKILL.md
+++ b/plugins/data-analytics/skills/data-modeling/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: data-modeling
+description: Designs the warehouse and semantic layer — source-to-mart structure, dimensional modeling, grain, slowly changing dimensions, and the metric layer analytics reads through. Use this to design or restructure a warehouse, model a new source, decide on grain or table structure, build a semantic or metric layer, or diagnose why queries are slow, wrong, or impossible to write.
+---
+
+# Data modeling
+
+## Layers, and why the middle one matters
+
+Three layers, each with one job:
+
+1. **Raw** — source data, unmodified, append-only. Never transform on ingest; you cannot recover what
+   you discarded, and you will want it.
+2. **Staging** — cleaned and conformed: consistent types, standardized names, deduplicated, no
+   business logic yet.
+3. **Marts** — business-facing models shaped for how questions are asked.
+
+The discipline that pays is keeping business logic out of layers 1 and 2. Logic embedded in ingestion
+cannot be changed retroactively, and it will need to change.
+
+## Grain is the decision everything follows from
+
+State the grain of every table in one sentence: *one row per what*. "One row per order line per day"
+is a grain. "Order data" is not.
+
+Most modeling errors are grain errors, and they surface as fan-out — a join multiplying rows so every
+downstream sum is inflated. If a number is mysteriously too high, check the grain before checking the
+logic.
+
+## Dimensional structure
+
+Facts for events and measurements; dimensions for the things being described. Keep facts narrow and
+long, dimensions wide and short.
+
+Conform dimensions across facts — one customer dimension, used everywhere. Separate customer tables
+per domain is how the same customer gets counted differently in two reports.
+
+**Handle history deliberately.** Overwriting a dimension attribute rewrites the past: last year's
+revenue silently re-attributes to this year's segment. Decide per attribute whether history matters,
+and where it does, keep versions with valid-from and valid-to.
+
+## The semantic layer
+
+Define metrics once, above the marts, and have every consumer read through it. Without it, the same
+metric is reimplemented in each dashboard and they drift — not because anyone is careless, but
+because a filter differs.
+
+The semantic layer is where the metric dictionary becomes executable rather than documentary.
+
+## Performance
+
+Model for the query pattern you actually have. Pre-aggregate what is queried constantly; leave the
+long tail to compute on demand.
+
+Partition and cluster on what people filter by — usually time, then a tenant or entity key. Most slow
+warehouse queries are full scans of a table that could have been partitioned by date.
+
+Denormalize deliberately, and write down why. Undocumented denormalization is indistinguishable from
+a modeling error six months later.
+
+## Never
+
+- Build a mart directly on raw. The coupling means every source change breaks the business layer.
+- Mix grains in one table.
+- Let a dashboard contain business logic the warehouse does not. That logic is invisible and
+  unversioned.

--- a/scripts/build-readme.py
+++ b/scripts/build-readme.py
@@ -13,6 +13,9 @@ ORDER = [
     ("revenue",           "Revenue",            "CRO"),
     ("finance",           "Finance",            "CFO"),
     ("operations",        "Operations",         "COO"),
+    ("customer-experience","Customer Experience","CCO"),
+    ("data-analytics",    "Data & Analytics",   "CDO"),
+    ("corporate-strategy","Corporate Strategy", "CSO"),
     ("people",            "People",             "CHRO"),
     ("legal-risk",        "Legal & Risk",       "CLO / CCO"),
 ]

--- a/scripts/build-readme.py
+++ b/scripts/build-readme.py
@@ -130,7 +130,32 @@ out += [
 ]
 content = "\n".join(out)
 
+# The org chart's department table drifts the same way the README did. Generate it between
+# markers so the two cannot disagree; the analysis prose around it stays hand-written.
+chart_rows = "\n".join(
+    f"| `{d}` | {t} | {e} | {len(skills(d))}"
+    + (" · reviewer-class |" if d in REVIEWER else " |")
+    for d, t, e in ORDER
+)
+chart_block = (
+    "<!-- BEGIN GENERATED: departments -->\n"
+    f"| Department | Function | Executive | Skills |\n|---|---|---|---|\n{chart_rows}\n"
+    f"\n{len(ORDER)} departments, {total} skills.\n"
+    "<!-- END GENERATED: departments -->"
+)
+chart_path = "docs/org-chart.md"
+chart_current = open(chart_path, encoding="utf-8").read()
+chart_new = re.sub(
+    r"<!-- BEGIN GENERATED: departments -->.*?<!-- END GENERATED: departments -->",
+    lambda _: chart_block,
+    chart_current,
+    flags=re.S,
+)
+
 if "--check" in sys.argv:
+    if chart_current != chart_new:
+        print("  docs/org-chart.md department table is stale — run: python3 scripts/build-readme.py")
+        sys.exit(1)
     current = open("README.md", encoding="utf-8").read() if os.path.exists("README.md") else ""
     if current != content:
         print("  README.md is stale — run: python3 scripts/build-readme.py")
@@ -139,4 +164,5 @@ if "--check" in sys.argv:
     sys.exit(0)
 
 open("README.md", "w", encoding="utf-8").write(content)
-print(f"README.md regenerated — {len(ORDER)} departments, {total} skills")
+open(chart_path, "w", encoding="utf-8").write(chart_new)
+print(f"README.md and org-chart.md regenerated — {len(ORDER)} departments, {total} skills")


### PR DESCRIPTION
Resolves D17 by building all three proposed gaps together rather than sequencing them. **14 departments, 101 skills.**

## `customer-experience` (CCO)

The most conspicuous absence — every business has support, and the catalogue had none.

`chief-customer-officer` · `support-operations` · `escalation-management` · `voice-of-customer` · `self-service-and-knowledge`

## `data-analytics` (CDO)

Previous coverage was marketing measurement only.

`chief-data-officer` · `data-governance` · `data-modeling` · `business-intelligence` · `ai-ml-governance`

`ai-ml-governance` opens by stating that automated decisions affecting credit, employment, housing, insurance, healthcare, or education carry specific legal obligations and are not an engineering question — those regimes are changing quickly and confidently-wrong guidance there is expensive.

## `corporate-strategy` (CSO)

`chief-strategy-officer` · `portfolio-strategy` · `mergers-and-acquisitions` · `strategic-alliances` · `scenario-planning`

`mergers-and-acquisitions` states up front that deal execution requires qualified legal, tax, and accounting advisers.

## Boundaries drawn deliberately

These three could easily have overlapped what exists. Where they came close:

| New skill | Distinguished from |
|---|---|
| `strategic-alliances` | `marketing:partnership-marketing` — alliances change what the business can *do*; partnership marketing borrows an *audience* |
| `chief-strategy-officer` | `executive:chief-executive` — multi-year horizon vs. arbitrating the present quarter |
| `portfolio-strategy` | `executive:business-growth-consultant` — allocating across business lines vs. finding the constraint within one |
| `business-intelligence` | `demand-generation:marketing-analytics` — org-wide reporting vs. marketing measurement |
| `voice-of-customer` | `marketing:customer-research` — inbound feedback loop vs. commissioned research |

Each description names the distinction so triggers don't collide.

## Verification

```
Agent surfaces passed.        (15 builders, 2 reviewers, 17 charters)
101 skills checked, 0 problems
provenance: 0 problems
README is current
manifests: 0 problems
```

## D20 — the publishing steps I can't reach

No tool in this session exposes repository settings, so these need your hands, in order of value:

1. **Topics** — `claude-code`, `claude-skills`, `ai-agents`, `agent-marketplace`, `claude-plugins`. This is how anyone finds it, and it's the step most often skipped.
2. **About** — suggested: *"An agent organization for Claude Code: a C-suite of 14 departments and 101 skills, installable per department."*
3. **Settings → General → Automatically delete head branches** — three merged branches have needed manual deletion so far.
4. Optional: default merge to squash; pin on profile; `cbrock84/cbrock84` profile README.

`verify` stays red until 1 September — exhausted Actions minutes, no runner allocated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_