### PR TITLE
Rename to headcount, add CONTRIBUTING.md, record D21/D22

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "agents-v1",
+  "name": "headcount",
   "owner": {
     "name": "Chris Brock"
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,13 @@ terms as the rest of this repository.**
 Contribute only work you have the right to license this way. In particular, do not paste in skills,
 prose, or reference material from another project unless you wrote it or its licence permits
 relocation — and if it does, say so in the pull request. Every line in this repository is original
-to it, and `scripts/check-provenance.py` fails the build if third-party licence text, copyright
-notices, or font assets appear.
+to it.
+
+`scripts/check-provenance.py` is a backstop, not a proof. It scans every text file in the tree for
+licence headers, copyright notices, and SPDX identifiers, flags files named like licences
+(`LICENSE`, `COPYING`, `NOTICE`, `PATENTS`, `AUTHORS`), and rejects bundled font assets. It cannot
+detect prose lifted without a notice attached — which is the case that matters most. Review is what
+catches that; the check only catches the obvious.
 
 ## What makes a good skill
 
@@ -51,7 +56,7 @@ Four checks, the same ones CI runs:
 |---|---|
 | Surface map | Every tracked path has exactly one owner |
 | Skill frontmatter | `name` equals the directory name, lowercase-hyphenated, unique, description substantial |
-| Provenance | No third-party licence text, copyright notices, or font assets |
+| Provenance | No licence headers, copyright notices, licence-named files, or font assets |
 | Generated docs | README and org-chart tables match the tree |
 
 **Stage your files first.** The surface guard reads `git ls-files`, so an unstaged file is invisible
@@ -68,12 +73,17 @@ present.
 
 ## Adding a department
 
-All four, in the same change, or the check fails:
+All five, in the same change, or the check fails:
 
 1. `plugins/<name>/skills/` and `plugins/<name>/.claude-plugin/plugin.json`
 2. A roster row and a `surface:` block in `docs/AGENT-SURFACES.md`
 3. A charter at `.claude/agents/<name>.md`
 4. An entry in `.claude-plugin/marketplace.json`
+5. A `(rank, title, executive)` entry in `META` in `scripts/build-readme.py`, then regenerate with
+   `python3 scripts/build-readme.py`
+
+The generator reads the department list off disk and refuses to run until step 5 is done, so a new
+department cannot end up missing from the README and the org chart while the checks still pass.
 
 Give it a chief before any specialists — the department's remit should exist before things are added
 to it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing
+
+Contributions are welcome. This document covers the licence, the bar for a skill, and the checks.
+
+## Licence
+
+**By submitting a contribution you agree it is licensed under the [MIT Licence](LICENSE), the same
+terms as the rest of this repository.**
+
+Contribute only work you have the right to license this way. In particular, do not paste in skills,
+prose, or reference material from another project unless you wrote it or its licence permits
+relocation — and if it does, say so in the pull request. Every line in this repository is original
+to it, and `scripts/check-provenance.py` fails the build if third-party licence text, copyright
+notices, or font assets appear.
+
+## What makes a good skill
+
+A skill is judged twice: whether it loads at the right moment, and whether it helps once loaded.
+
+**The description does the triggering.** It is the only part read when deciding whether to load. Lead
+with what the skill does, then when to reach for it — in the words someone would actually use,
+including the oblique ones. Vague descriptions fail twice over: they miss cases they should catch
+and fire on cases they cannot help.
+
+**The body does the work.** Write for someone competent who has not thought about this problem
+today:
+
+- **Method over exhortation.** "Be thorough" is noise; an ordered procedure is instruction.
+- **State the failure behind each rule.** A rule with no failure attached gets optimized away by the
+  next reader.
+- **Be specific enough to be wrong.** Guidance too hedged to contradict is too vague to follow.
+- **Long material goes in `references/`**, with the body saying when to read it.
+
+**Where a skill touches regulated ground** — law, privacy, compensation, medical, financial, or
+safety advice — say plainly what it structures and what needs qualified professional input. Skills
+that sound authoritative and are subtly wrong in these areas cause real harm, because they get
+trusted.
+
+Read `technology:skill-authoring` for the full treatment, and `executive:agent-hierarchy` for why
+departments are split by exclusive write surface rather than by topic.
+
+## Before opening a pull request
+
+```
+./scripts/check-all.sh
+```
+
+Four checks, the same ones CI runs:
+
+| Check | What it enforces |
+|---|---|
+| Surface map | Every tracked path has exactly one owner |
+| Skill frontmatter | `name` equals the directory name, lowercase-hyphenated, unique, description substantial |
+| Provenance | No third-party licence text, copyright notices, or font assets |
+| Generated docs | README and org-chart tables match the tree |
+
+**Stage your files first.** The surface guard reads `git ls-files`, so an unstaged file is invisible
+to it — the check will pass and then fail once committed. The script warns when untracked files are
+present.
+
+## Adding a skill
+
+1. `plugins/<department>/skills/<skill-name>/SKILL.md`
+2. Frontmatter `name` must equal the directory name.
+3. Check nothing already covers the ground. Two skills whose descriptions both match a request means
+   neither reliably wins — prefer extending an existing skill, or folding a family into one skill
+   with references, over adding a near-neighbour.
+
+## Adding a department
+
+All four, in the same change, or the check fails:
+
+1. `plugins/<name>/skills/` and `plugins/<name>/.claude-plugin/plugin.json`
+2. A roster row and a `surface:` block in `docs/AGENT-SURFACES.md`
+3. A charter at `.claude/agents/<name>.md`
+4. An entry in `.claude-plugin/marketplace.json`
+
+Give it a chief before any specialists — the department's remit should exist before things are added
+to it.
+
+## Adding a file outside `plugins/`
+
+It needs an owner in `docs/AGENT-SURFACES.md`, or the surface check fails. Most such files belong to
+`repo-meta`.
+
+## Decisions
+
+Choices with more than one defensible answer go in `docs/DECISION-LOG.md`, numbered. A number is
+assigned when the question is raised, not when it is answered, and is never reused. Every entry
+carries lettered options and an explicit recommendation.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# agents-v1
+# headcount
+
+**Add a department, not a prompt.**
 
 An agent organization for [Claude Code](https://claude.com/claude-code), structured as a company:
 a chief executive over 14 departments, 101 skills in total.
@@ -9,8 +11,8 @@ needs rather than all of them at once.
 ## Install
 
 ```
-/plugin marketplace add cbrock84/agents-v1
-/plugin install security@agents-v1
+/plugin marketplace add cbrock84/headcount
+/plugin install security@headcount
 ```
 
 Install as many departments as the project needs. Skills are addressed as `department:skill` —

--- a/docs/AGENT-SURFACES.md
+++ b/docs/AGENT-SURFACES.md
@@ -99,6 +99,7 @@ plugins/security/**
 
 ```surface:repo-meta
 LICENSE
+CONTRIBUTING.md
 docs/**
 scripts/**
 .github/**

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -357,8 +357,8 @@ files already in this PR's scope.
 
 ## D16. Repo visibility versus marketplace distribution — ✅ Resolved
 
-`cbrock84/agents-v1` is **private**, but the README instructs `/plugin marketplace add
-cbrock84/agents-v1`. A private marketplace requires each installing machine to be authenticated to
+`cbrock84/headcount` is **private**, but the README instructs `/plugin marketplace add
+cbrock84/headcount`. A private marketplace requires each installing machine to be authenticated to
 this repository, which the instructions do not mention.
 
 - (a) Keep private, and document the authentication requirement in the README.
@@ -524,3 +524,55 @@ Neither is true now.
 
 **Not legal advice.** For the productized vertical variants contemplated in D8, where money and
 third-party distribution are involved, this is worth qualified counsel rather than a decision log.
+
+---
+
+## D22. What to call this — ✅ Resolved
+
+`agents-v1` was a working title. It describes the mechanism (agents) and a version number, neither of
+which is a name, and it was about to be published — at which point the name stops being free to
+change.
+
+The binding constraint is not aesthetics. It is that the brand appears **after an `@` in every
+install command**:
+
+```
+/plugin marketplace add cbrock84/NAME
+/plugin install security@NAME
+```
+
+`security@NAME` renders as a corporate email address. That is free explanation of the whole product,
+but only for a name that reads like a company. It rules out descriptive multi-word names.
+
+- **(a) `headcount`.** ← **chosen**
+- (b) `holdco` — a holding company holds operating subsidiaries; this holds installable departments.
+  Structurally exact, and less likely to collide with an existing product.
+- (c) `boardroom`, `roster`, `charter`, `quorum` — all read as companies; each is either semantically
+  off (a boardroom is the board, not the operating org) or heavily used elsewhere.
+- (d) `company-in-a-box` and relatives — say exactly what it is, but are not distinctive and destroy
+  the `@` construction.
+- (e) Keep `agents-v1`.
+
+**Resolution: (a).**
+
+- **It names the benefit, not the mechanism.** "101 markdown skills in a plugin marketplace" is what
+  it is made of. "Headcount" is what someone wants: a CISO, a CFO, a growth lead, without the req.
+- **The install string becomes the tagline.** `/plugin install security@headcount` reads as hiring a
+  security department. Nothing further needs explaining.
+- **It survives D8.** Generated verticals are `headcount-health`, `headcount-retail`,
+  `headcount-industrial` — which parse as staffing firms with a specialty. The metaphor strengthens
+  as it is cloned, which is unusual and worth the points.
+
+**This sets the vertical naming convention for D8**, whose resolution (c) emits standalone repos:
+each generated vertical is `headcount-<vertical>`, and the generator's per-vertical config carries
+the suffix. Recorded here so the generator is not built against a different scheme.
+
+**Name-collision caveat, not resolved by this entry.** `headcount` is a common noun in HR software
+and this log is not a trademark search. The check is worth doing before any commercial use of the
+D7/D8 productized variants; for an MIT repository under a personal account the exposure is low.
+`holdco` (b) remains the fallback if a conflict surfaces, and is a cheap swap while the name is
+young — the same timing logic as D21.
+
+**Timing.** Renaming cost one commit here. After publication the install string gets copied into
+config files, posts and screenshots that never update — GitHub redirects renamed repositories, but
+it cannot rewrite what people have already pasted elsewhere. This was the last moment it was free.

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -477,3 +477,50 @@ The list, in order of value:
 
 **Recommendation: (b).** 1–3 matter; 4 is preference; 5 is worth doing only if you want the profile
 to lead with this.
+
+## D21. MIT or Apache-2.0 for the long term — ✅ Resolved
+
+Raised while preparing to publish. Apache-2.0 is the usual alternative to MIT for a project intended
+for wide reuse.
+
+**What Apache-2.0 adds over MIT:** an explicit patent grant with a retaliation clause, an explicit
+trademark carve-out, a requirement that modified files carry a notice of change, and automatic terms
+for inbound contributions.
+
+- **(a) MIT.** ← **chosen**
+- (b) Apache-2.0.
+- (c) A content licence such as CC-BY-4.0.
+- (d) Dual — CC-BY for the prose, MIT for the scripts.
+
+**Resolution: (a).** The reasoning, recorded so it is not re-litigated:
+
+- **The patent grant is Apache's headline feature and is near-irrelevant here.** This repository is
+  markdown. Instructions for running a threat model or a CRO audit are not patentable subject matter
+  in any practical sense, so the protection Apache exists to provide has almost nothing to attach to.
+- **Apache §4(b) is active friction for the intended use.** It requires modified files to carry
+  prominent change notices. The whole design is people installing a department and adapting it; MIT
+  lets them, Apache asks them to annotate every file they touch.
+- **MIT is the ecosystem norm.** Every collection this repository originally drew from was MIT, and
+  the Claude skills and plugins ecosystem is MIT by convention. Lower friction, fewer legal reviews.
+- **Short licences get complied with.** Two hundred lines of licence on a prose repository invites
+  the question of whether anyone read it.
+- **(c) and (d) rejected:** Creative Commons explicitly advises against using CC for software, this
+  repository contains executable scripts alongside the prose, and a split licence confuses tooling
+  and adopters for no practical gain.
+
+**The one real gap MIT leaves** — what licence inbound contributions carry — is closed by
+`CONTRIBUTING.md` stating that contributions are accepted under MIT, rather than by changing the
+licence.
+
+**Timing note, which is the part that matters later.** Relicensing is clean only while there is a
+single copyright holder. Once outside contributions land under MIT, you cannot retroactively un-MIT
+what has been published; you would be layering Apache over MIT-licensed parts, which is lawful but
+messy. So this decision is cheap to reverse **today** and expensive to reverse after the first
+external pull request.
+
+**Revisit if** the repository grows substantial executable code — the vertical generator in D8 is the
+plausible candidate — or if a corporate adopter's legal team specifically asks for the patent grant.
+Neither is true now.
+
+**Not legal advice.** For the productized vertical variants contemplated in D8, where money and
+third-party distribution are involved, this is worth qualified counsel rather than a decision log.

--- a/docs/cross-org-sweep-prompt.md
+++ b/docs/cross-org-sweep-prompt.md
@@ -1,8 +1,8 @@
 # Cross-org sweep prompt
 
 A Claude Code session can only attach repositories from **one owner**. A session rooted at
-`cbrock84/agents-v1` cannot attach `Keel-GRC/*` or `Drummond-IT/*`, and a session rooted in
-either of those cannot attach `agents-v1`. No single session sees both sides.
+`cbrock84/headcount` cannot attach `Keel-GRC/*` or `Drummond-IT/*`, and a session rooted in
+either of those cannot attach `headcount`. No single session sees both sides.
 
 That restriction applies to **attaching** — which is what push access and the GitHub API need.
 It does **not** apply to reading: the session's git proxy serves anonymous clones of any
@@ -12,7 +12,7 @@ So the split is:
 
 | Repos | How to reach them |
 |---|---|
-| Public `Keel-GRC/*` and `Drummond-IT/*` | Readable from the `agents-v1` session directly — no separate session needed |
+| Public `Keel-GRC/*` and `Drummond-IT/*` | Readable from the `headcount` session directly — no separate session needed |
 | Private / internal `Keel-GRC/*` and `Drummond-IT/*` | Need a session rooted in that org, which then hands results back as a file |
 
 Use the prompt below only for the second row.
@@ -30,7 +30,7 @@ Sweep this organization's **private and internal** repositories for Claude agent
 agent-definition material, and package what you find so it can be moved into another repo.
 
 **Constraint, so you don't waste time on it:** this session is locked to this org's owner. You
-cannot attach `cbrock84/agents-v1`, and you cannot push there. The deliverable is a file you
+cannot attach `cbrock84/headcount`, and you cannot push there. The deliverable is a file you
 hand back, not a commit. Public repos in this org do not need you — they are readable from the
 other session directly, so **skip anything public** and spend your budget on private/internal
 repos only.
@@ -82,7 +82,7 @@ as files.
 
 ## Bringing the results back
 
-Attach the tarball (or paste `REPORT.md`) in the `agents-v1` session and say which departments
+Attach the tarball (or paste `REPORT.md`) in the `headcount` session and say which departments
 they should land in. Existing departments are `engineering`, `marketing`, `content`, `design`;
 GRC material most likely wants a new `compliance` department, and Drummond print/prepress
 material a `print-production` one.

--- a/plugins/corporate-strategy/.claude-plugin/plugin.json
+++ b/plugins/corporate-strategy/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "strategy",
     "corp-dev",

--- a/plugins/customer-experience/.claude-plugin/plugin.json
+++ b/plugins/customer-experience/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "support",
     "customer-success",

--- a/plugins/data-analytics/.claude-plugin/plugin.json
+++ b/plugins/data-analytics/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "data",
     "analytics",

--- a/plugins/demand-generation/.claude-plugin/plugin.json
+++ b/plugins/demand-generation/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "seo",
     "paid-ads",

--- a/plugins/executive/.claude-plugin/plugin.json
+++ b/plugins/executive/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "strategy",
     "executive",

--- a/plugins/finance/.claude-plugin/plugin.json
+++ b/plugins/finance/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "finance",
     "budgeting",

--- a/plugins/legal-risk/.claude-plugin/plugin.json
+++ b/plugins/legal-risk/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "legal",
     "privacy",

--- a/plugins/marketing/.claude-plugin/plugin.json
+++ b/plugins/marketing/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "marketing",
     "content",

--- a/plugins/operations/.claude-plugin/plugin.json
+++ b/plugins/operations/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "operations",
     "process",

--- a/plugins/people/.claude-plugin/plugin.json
+++ b/plugins/people/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "people",
     "hr",

--- a/plugins/product/.claude-plugin/plugin.json
+++ b/plugins/product/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "product",
     "ux",

--- a/plugins/revenue/.claude-plugin/plugin.json
+++ b/plugins/revenue/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "sales",
     "pricing",

--- a/plugins/security/.claude-plugin/plugin.json
+++ b/plugins/security/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "security",
     "appsec",

--- a/plugins/technology/.claude-plugin/plugin.json
+++ b/plugins/technology/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Chris Brock"
   },
-  "repository": "https://github.com/cbrock84/agents-v1",
+  "repository": "https://github.com/cbrock84/headcount",
   "keywords": [
     "engineering",
     "tdd",

--- a/scripts/build-readme.py
+++ b/scripts/build-readme.py
@@ -64,7 +64,9 @@ def skills(dept):
 
 total = sum(len(skills(d)) for d, _, _ in ORDER)
 out = [
-    "# agents-v1",
+    "# headcount",
+    "",
+    "**Add a department, not a prompt.**",
     "",
     "An agent organization for [Claude Code](https://claude.com/claude-code), structured as a company:",
     f"a chief executive over {len(ORDER)} departments, {total} skills in total.",
@@ -75,8 +77,8 @@ out = [
     "## Install",
     "",
     "```",
-    "/plugin marketplace add cbrock84/agents-v1",
-    "/plugin install security@agents-v1",
+    "/plugin marketplace add cbrock84/headcount",
+    "/plugin install security@headcount",
     "```",
     "",
     "Install as many departments as the project needs. Skills are addressed as `department:skill` —",

--- a/scripts/build-readme.py
+++ b/scripts/build-readme.py
@@ -3,23 +3,48 @@
 and verified in CI so the README can never drift from what the repo actually contains."""
 import glob, os, re, json, sys
 
-ORDER = [
-    ("executive",         "Office of the CEO",  "Chief Executive"),
-    ("technology",        "Technology",         "CTO / CIO"),
-    ("security",          "Security",           "CISO"),
-    ("product",           "Product",            "CPO"),
-    ("marketing",         "Marketing",          "CMO"),
-    ("demand-generation", "Demand Generation",  "CMO"),
-    ("revenue",           "Revenue",            "CRO"),
-    ("finance",           "Finance",            "CFO"),
-    ("operations",        "Operations",         "COO"),
-    ("customer-experience","Customer Experience","CCO"),
-    ("data-analytics",    "Data & Analytics",   "CDO"),
-    ("corporate-strategy","Corporate Strategy", "CSO"),
-    ("people",            "People",             "CHRO"),
-    ("legal-risk",        "Legal & Risk",       "CLO / CCO"),
-]
+# Display metadata per department. The department list itself comes from the plugin tree — see
+# load_departments() — so a department cannot be added to disk and silently omitted from the docs.
+# The rank fixes reporting order: the chief executive first, then the functions beneath.
+META = {
+    "executive":          (10, "Office of the CEO",   "Chief Executive"),
+    "technology":         (20, "Technology",          "CTO / CIO"),
+    "security":           (30, "Security",            "CISO"),
+    "product":            (40, "Product",             "CPO"),
+    "marketing":          (50, "Marketing",           "CMO"),
+    "demand-generation":  (60, "Demand Generation",   "CMO"),
+    "revenue":            (70, "Revenue",             "CRO"),
+    "finance":            (80, "Finance",             "CFO"),
+    "operations":         (90, "Operations",          "COO"),
+    "customer-experience": (100, "Customer Experience", "CCO"),
+    "data-analytics":     (110, "Data & Analytics",   "CDO"),
+    "corporate-strategy": (120, "Corporate Strategy", "CSO"),
+    "people":             (130, "People",             "CHRO"),
+    "legal-risk":         (140, "Legal & Risk",       "CLO / CCO"),
+}
 REVIEWER = {"security", "legal-risk"}
+
+
+def load_departments():
+    """Departments come from disk, not from a list someone has to remember to update. A department
+    present on disk but missing from META is a hard error rather than a silent omission — the same
+    mistake used to drop a department out of both generated docs while --check still passed."""
+    found = {os.path.basename(os.path.dirname(os.path.dirname(m)))
+             for m in glob.glob("plugins/*/.claude-plugin/plugin.json")}
+    missing = sorted(found - set(META))
+    if missing:
+        sys.exit("build-readme: no display metadata for department(s) "
+                 + ", ".join(missing)
+                 + "\n  add a (rank, title, executive) entry to META in scripts/build-readme.py")
+    stale = sorted(set(META) - found)
+    if stale:
+        sys.exit("build-readme: META names department(s) that are not on disk: "
+                 + ", ".join(stale)
+                 + "\n  remove them from META in scripts/build-readme.py")
+    return [(d, META[d][1], META[d][2]) for d in sorted(found, key=lambda d: META[d][0])]
+
+
+ORDER = load_departments()
 
 
 def summarize(path, limit=165):

--- a/scripts/check-provenance.py
+++ b/scripts/check-provenance.py
@@ -1,35 +1,76 @@
 #!/usr/bin/env python3
-"""All content here is original. Fail if third-party licence text or upstream names reappear."""
+"""All content here is original. This is a heuristic backstop, not proof: it catches the common
+shapes of third-party licence text and vendored assets. It cannot detect prose copied without a
+notice, so it supplements review rather than replacing it."""
 import glob, os, re, sys
 
+# Markers for the licences most likely to arrive with vendored material.
 PATTERNS = [
     r"\bMIT License\b",
-    r"Permission is hereby granted",
-    r"Copyright \(c\)",
-    r"\bSPDX-License-Identifier\b",
+    r"\bApache License\b",
+    r"\bGNU (?:GENERAL|LESSER|AFFERO)\b",
+    r"\bBSD \d-Clause\b",
+    r"\bMozilla Public License\b",
     r"\bSIL Open Font License\b",
+    r"\bCreative Commons Attribution\b",
+    r"Permission is hereby granted",
+    r"Redistribution and use in source and binary forms",
+    r"Copyright\s*(?:\(c\)|©)",
+    r"\bSPDX-License-Identifier\b",
+    r"\bAll rights reserved\b",
 ]
-# Our own MIT LICENSE at the repo root is expected; any other licence file is not.
-OWN_LICENSE = "LICENSE"
-BANNED_FILES = ("licence", "license", "ofl", ".ttf", ".otf", ".woff")
+
+# Filenames that carry someone else's terms, whatever their extension.
+LICENCE_NAMES = re.compile(
+    r"^(licen[cs]e|copying|notice|patents|authors|ofl)(\..*)?$|licen[cs]e", re.I
+)
+# Binary assets that are always third-party when present.
+ASSET_EXTS = (".ttf", ".otf", ".woff", ".woff2", ".eot")
+
+OWN_LICENCE = "LICENSE"  # ours, and the only one expected
+SKIP_DIRS = (".git/",)
+
+
+def is_probably_text(path, sniff=4096):
+    try:
+        with open(path, "rb") as handle:
+            chunk = handle.read(sniff)
+    except OSError:
+        return False
+    if b"\0" in chunk:
+        return False
+    try:
+        chunk.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
 
 problems = []
 for path in glob.glob("**/*", recursive=True):
-    if not os.path.isfile(path) or path.startswith(".git/"):
+    if not os.path.isfile(path) or path.startswith(SKIP_DIRS):
         continue
     if os.path.abspath(path) == os.path.abspath(__file__):
         continue  # this file necessarily contains the patterns it searches for
-    if path == OWN_LICENSE:
+    if path == OWN_LICENCE:
         continue
-    if any(token in os.path.basename(path).lower() for token in BANNED_FILES):
-        problems.append(f"{path}: third-party licence or font asset")
+
+    name = os.path.basename(path)
+    if name.lower().endswith(ASSET_EXTS):
+        problems.append(f"{path}: third-party font asset")
         continue
-    if os.path.splitext(path)[1] not in (".md", ".json", ".mjs", ".py", ".yml"):
+    if LICENCE_NAMES.match(name):
+        problems.append(f"{path}: third-party licence or notice file")
+        continue
+
+    # Every text file, whatever its extension — an extension allowlist is how a .txt slips past.
+    if not is_probably_text(path):
         continue
     text = open(path, encoding="utf-8", errors="replace").read()
     for pattern in PATTERNS:
         if re.search(pattern, text):
             problems.append(f"{path}: matches {pattern!r}")
+            break
 
 for problem in problems:
     print(f"  {problem}")


### PR DESCRIPTION
Everything that had to happen before publishing, in one change.

## Rename: `agents-v1` → `headcount` (D22)

`agents-v1` was a working title — it names the mechanism and a version number, neither of which is a name.

The constraint that picked the replacement is that the brand sits **after an `@` in every install command**:

```
/plugin marketplace add cbrock84/headcount
/plugin install security@headcount
```

`security@headcount` renders as a corporate email address, so the install string explains the product on its own. That only works for a name reading like a company, which rules out the descriptive multi-word candidates. `headcount` also names the benefit rather than the mechanism — a CISO or a CFO without the req — and it survives D8: generated verticals become `headcount-health`, `headcount-retail`, which parse as staffing firms with a specialty.

All 28 references updated: the marketplace identity (source of the `@name` suffix), 14 plugin repository URLs, the README generator's title and install block, and path references in the decision log and sweep prompt. README and org chart regenerated.

D22 also **fixes the vertical naming convention D8's generator must target** — `headcount-<vertical>` — so it isn't built against a different scheme, and records the name-collision caveat a decision log can't settle.

## `CONTRIBUTING.md`

The load-bearing line: **contributions are accepted under MIT.** That closes the one real gap the licence leaves — MIT is silent on inbound contribution terms where Apache-2.0 §5 is explicit.

One instruction worth flagging: skills touching law, privacy, compensation, medical, financial, or safety ground must say plainly what they structure and what needs qualified professional input. That's the failure mode with real consequences in a catalogue anyone can install — confident and subtly wrong gets trusted.

## D21: staying MIT

- Apache's patent grant is its headline feature and is **near-irrelevant for markdown** — instructions for a threat model aren't patentable subject matter, so the protection has nothing to attach to
- Apache §4(b) requires modified files to carry change notices — **active friction** for people installing a department and adapting it
- MIT is the ecosystem norm; CC-BY rejected because Creative Commons advises against CC for software and this repo has executable scripts

**Timing is the part that matters later:** relicensing is clean only while there's a single copyright holder. Cheap to reverse today, expensive after the first external PR.

## Two review findings, both real, both fixed (68c8cda)

Reproduced before fixing, in both cases.

**Provenance check was narrower than the doc claimed.** It scanned only `.md/.json/.mjs/.py/.yml`, so a bundled GPL `COPYING` or a copyright notice in a `.txt` passed silently. It now binary-sniffs and scans every text file regardless of extension, matches twelve licence markers, and flags files *named* like licences. The doc no longer presents it as proof — it is a backstop that cannot detect prose lifted without a notice attached.

**A new department could vanish from the generated docs.** `build-readme.py` rendered only departments in a hard-coded `ORDER` list, and `--check` still passed because it compared against the same incomplete list. The list now comes off the plugin tree, and a mismatch in either direction is a hard exit naming the file to edit.

## Ordering note

`marketplace.json` now says `headcount`, so the install commands in the README are correct **only once the GitHub repo is renamed** — that's a settings change no tool in this session can make. Rename the repo before or right after merging; GitHub redirects the old path, so nothing breaks in between.

All five checks pass locally. `verify` is red until 1 September on exhausted Actions minutes — confirmed red on `main`'s own head too, so it is not this PR's failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_