### PR TITLE
Post-publication: README badges, language detection, CI hardening, D18–D24

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# GitHub's language bar is computed by Linguist, which by default weighs a single
+# tooling script more heavily than the prose that is actually the product. Without
+# this the repository is labelled "JavaScript" on the strength of one .mjs guard.
+#
+# Skills are the deliverable, so they count. Tooling and generated docs do not.
+scripts/*        linguist-vendored
+*.mjs            linguist-vendored
+README.md        linguist-generated
+docs/org-chart.md linguist-generated
+plugins/**/*.md  linguist-detectable

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,9 +15,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
       # Same entry point as `./scripts/check-all.sh` locally, so the two cannot drift.
       - run: ./scripts/check-all.sh

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,8 +2,14 @@ name: checks
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
+
+# The workflow only reads the tree and runs checks; it never writes back. Setting this
+# explicitly means a permissive account-level default cannot silently hand a write-scoped
+# token to a workflow triggered from a fork.
+permissions:
+  contents: read
 
 jobs:
   verify:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# headcount
+<h1 align="center">headcount</h1>
 
-**Add a department, not a prompt.**
+<p align="center"><b>Add a department, not a prompt.</b></p>
+
+<p align="center">
+  <a href="https://claude.com/claude-code"><img alt="Built for Claude Code" src="https://img.shields.io/badge/built%20for-Claude%20Code-D97757?style=flat-square"></a>
+  <img alt="14 departments" src="https://img.shields.io/badge/departments-14-3F4B5B?style=flat-square">
+  <img alt="101 skills" src="https://img.shields.io/badge/skills-101-3F4B5B?style=flat-square">
+  <a href="LICENSE"><img alt="MIT licensed" src="https://img.shields.io/badge/license-MIT-3F4B5B?style=flat-square"></a>
+  <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-2EA043?style=flat-square"></a>
+</p>
 
 An agent organization for [Claude Code](https://claude.com/claude-code), structured as a company:
 a chief executive over 14 departments, 101 skills in total.

--- a/docs/AGENT-SURFACES.md
+++ b/docs/AGENT-SURFACES.md
@@ -100,6 +100,7 @@ plugins/security/**
 ```surface:repo-meta
 LICENSE
 CONTRIBUTING.md
+.gitattributes
 docs/**
 scripts/**
 .github/**

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -644,8 +644,25 @@ and generated documents as generated, so the language bar reflects the deliverab
   checks. Public repositories accept pull requests from forks, and being explicit means a permissive
   account-level default cannot hand a write-scoped token to a workflow triggered by a stranger.
 - **Push trigger narrowed from `["**"]` to `[main]`.** Every push was running the workflow twice —
-  once for the push, once for the pull request, on the same commit. This halves the Actions burn,
-  which is not academic: the account exhausted its minutes on 28 August and CI has been dark since.
+  once for the push, once for the pull request, on the same commit. Pure waste either way.
+- **Deprecated actions bumped.** The first green run warned that `actions/checkout@v4` and
+  `actions/setup-node@v4` run on Node 20, which is being force-migrated to Node 24. Both are now at
+  v7, with `node-version` at 24. Versions were checked against the actions' own release pages rather
+  than assumed — the guess would have been v5, and both are three majors further on than that.
+
+**The CI blackout ended, and not for the reason recorded.** Every run from 28 August onward failed in
+three to four seconds with no steps and empty output, on this repository and on `main` alike. That
+was diagnosed as exhausted Actions minutes, with the fix being the 1 September quota reset. The
+minutes were genuinely exhausted, but the reset was never the fix: **GitHub Actions is free and
+unlimited for public repositories on standard runners** (GitHub's own billing documentation:
+"GitHub Actions usage is free for self-hosted runners and for public repositories that use standard
+GitHub-hosted runners"). Making the repository public under D18 ended the blackout immediately —
+the first run after publishing went green in eight seconds, executing all five checks.
+
+Worth recording because the wrong lesson was nearly banked. The blackout was treated as an external
+constraint to wait out, and `scripts/check-all.sh` was built to decouple verification from CI while
+it lasted. That script earns its place regardless. But the constraint was a consequence of a setting
+this project had already decided to change, and nobody connected the two for a full day.
 
 **Deliberately not done.**
 

--- a/docs/DECISION-LOG.md
+++ b/docs/DECISION-LOG.md
@@ -392,7 +392,7 @@ of decisions.
 | 8 | Catalogue public Keel-GRC and Drummond repos — no import | D11 | — | |
 | 9 | Start a separate session against Keel-GRC for the private sweep | D11 | — | |
 | 10 | Build the vertical generator: core, per-vertical config, one-way emit | D8 | — | |
-| 11 | Revisit repo visibility | D16 | after 1 | |
+| 11 | Revisit repo visibility | D16 | after 1 | ✅ done |
 
 Items 1–4 can proceed in parallel; all four land before item 5. Item 9 needs a session started
 outside this one — see `docs/cross-org-sweep-prompt.md`.
@@ -426,7 +426,7 @@ this repo's likely users have not reached.
 **Resolution: all three, treated as equally important.** `customer-experience`, `data-analytics`,
 and `corporate-strategy` built together, five skills each. Fourteen departments, 101 skills.
 
-## D18. Repository visibility, now that all content is original — 🔵 Open
+## D18. Repository visibility, now that all content is original — ✅ Resolved
 
 D16 deferred this until the rewrite landed. It has. Nothing in the repository now carries a
 third-party obligation, and `scripts/check-provenance.py` fails the build if that changes.
@@ -440,7 +440,18 @@ third-party obligation, and `scripts/check-provenance.py` fails the build if tha
 **Recommendation: (a).** The blocker was provenance and it is resolved. Publishing does not commit
 you on D8 — a generator can emit per-vertical repos later regardless of whether this one is public.
 
-## D19. README drift — 🔵 Open
+**Resolution: (a).** `cbrock84/headcount` is public under MIT as of 29 August 2026, confirmed via the
+API (`visibility: public`). This also closes work-queue item 11, which existed only to revisit this.
+
+**What publishing actually changed.** The install path in the README now resolves for anyone — under
+D16 it required every installing machine to be authenticated to the account, which made the
+documented instructions untrue for everybody except the owner. That gap is closed.
+
+**Still unverified.** Nothing in this session can run `/plugin marketplace add` against a clean
+client, so the manifest is verified only up to "it parses and every referenced path exists". The
+first genuine test is an install from a machine that has never seen this repository.
+
+## D19. README drift — ✅ Resolved
 
 `scripts/build-readme.py` regenerates the README from the tree, and `check-all.sh` fails if it is
 stale. This works but means the README cannot be hand-edited.
@@ -453,7 +464,20 @@ stale. This works but means the README cannot be hand-edited.
 awkward.** The failure this prevents is real: the README claimed eleven departments and listed a
 deleted one for two commits before it was caught by hand.
 
-## D20. Publishing steps that need your hands — 🔵 Open
+**Resolution: (a), and the scope of generation has since widened twice.** The org chart's department
+table was moved inside generated markers after it drifted the same way, and the badge counts in the
+README header are now emitted from the same tree walk that builds the tables — so a wrong count is a
+CI failure rather than something a reader has to notice.
+
+The generator was also hardened after review: it discovers departments from the plugin tree instead
+of a hand-maintained list, and refuses to run when a department on disk has no display metadata. The
+earlier design would have omitted a new department from both documents while `--check` still passed,
+because it compared the files against output from the same incomplete list.
+
+**(b) remains the fallback** if the prose ever wants per-section nuance that the generator makes
+awkward. Nothing about that has changed.
+
+## D20. Publishing steps that need your hands — ✅ Resolved
 
 Repository settings are not reachable from this session — no tool exposes topics, description, or
 merge defaults, and the git proxy blocks branch deletion. These are yours to click.
@@ -477,6 +501,16 @@ The list, in order of value:
 
 **Recommendation: (b).** 1–3 matter; 4 is preference; 5 is worth doing only if you want the profile
 to lead with this.
+
+**Resolution: (b), executed 29 August 2026.** Repository renamed to `headcount` (D22), made public,
+description set, automatic head-branch deletion enabled, and the four stale merged branches deleted.
+`origin/main` is now the only remote branch.
+
+**One item outstanding, carried to D23:** topics are still empty. Verified via the API — the
+repository returns no topics array. This is the item the entry above called "the step most often
+skipped", and it was skipped, for a findable reason: **topics are not in Settings.** They live behind
+the gear icon on the About panel of the repository home page, which is where nobody looks for a
+setting. Noted here because the same confusion will recur on every vertical repo D8 emits.
 
 ## D21. MIT or Apache-2.0 for the long term — ✅ Resolved
 
@@ -576,3 +610,78 @@ young — the same timing logic as D21.
 **Timing.** Renaming cost one commit here. After publication the install string gets copied into
 config files, posts and screenshots that never update — GitHub redirects renamed repositories, but
 it cannot rewrite what people have already pasted elsewhere. This was the last moment it was free.
+
+---
+
+## D23. Buttoning up the repository now that it is public — ✅ Resolved
+
+Going public changes the threat model and the audience. Anyone can now fork, open a pull request
+that runs CI, and judge the project in about four seconds of looking at the landing page.
+
+- **(a) Presentation and hardening together, now.** ← **chosen**
+- (b) Presentation now, hardening when there is actual traffic.
+- (c) Neither; the repository is fine as it is.
+
+**Resolution: (a).** Both are cheap, and the hardening items are the kind that are embarrassing to
+add after an incident rather than before one.
+
+**Presentation — done in this change.**
+
+The README now opens with a centred title, the tagline, and a badge row: built-for Claude Code,
+department count, skill count, licence, and PRs-welcome. **The counts are generated from the same
+tree walk that builds the tables**, so they are covered by the existing staleness check — a badge
+claiming the wrong number fails CI. A hand-typed badge would have become a lie on the next
+department, which is precisely the D19 failure in a more visible place.
+
+**`.gitattributes` added.** GitHub labelled the repository *JavaScript* on the strength of a single
+`.mjs` guard script, against 101 markdown skills that are the actual product. Linguist counts bytes
+of code and does not know what a repository is for. The attributes file marks tooling as vendored
+and generated documents as generated, so the language bar reflects the deliverable.
+
+**Hardening — done in this change.**
+
+- **Explicit `permissions: contents: read` on the workflow.** It only reads the tree and runs
+  checks. Public repositories accept pull requests from forks, and being explicit means a permissive
+  account-level default cannot hand a write-scoped token to a workflow triggered by a stranger.
+- **Push trigger narrowed from `["**"]` to `[main]`.** Every push was running the workflow twice —
+  once for the push, once for the pull request, on the same commit. This halves the Actions burn,
+  which is not academic: the account exhausted its minutes on 28 August and CI has been dark since.
+
+**Deliberately not done.**
+
+- **Dependabot.** There are no dependency manifests — no `package.json`, no `requirements.txt`.
+  It would have nothing to scan, and enabling it would only add a quiet integration that never fires.
+- **Branch protection requiring approvals.** With a single maintainer, required approvals block the
+  only person who can approve. A ruleset requiring a pull request into `main`, with the owner as a
+  bypass actor, is the right shape if drive-by pushes ever become a concern; it is not one yet.
+
+**Left to the owner** (settings are not reachable from an agent session — see D20): topics, secret
+scanning with push protection, and turning off the unused Wiki and Projects tabs.
+
+---
+
+## D24. Whether to add sponsorship — ✅ Resolved
+
+GitHub Sponsors would put a **Sponsor** button on the repository, driven by `.github/FUNDING.yml`.
+
+- (a) Enrol and add `FUNDING.yml` now, with the repository.
+- **(b) Not yet — revisit at a real usage signal.** ← **chosen**
+- (c) Never; keep it a pure gift.
+
+**Resolution: (b).** Not on principle — the timing is simply wrong, and the cost of asking early is
+not zero.
+
+- **There is nothing to sponsor yet.** One star, no external installs, no issues, published today.
+  A funding ask is a claim that ongoing maintenance has value to someone; that claim is currently
+  unevidenced, and a reader can tell.
+- **It changes how the first impression reads.** A brand-new repository leading with a payment link
+  invites the question of whether the catalogue was assembled to be monetised. That is a costly
+  question to raise while the provenance story — 101 skills written from scratch after removing
+  every vendored collection — is the thing worth the reader's attention.
+- **It is thirty seconds whenever you want it.** Enrol at `github.com/sponsors`, then a two-line
+  `.github/FUNDING.yml` with `github: [cbrock84]`. Nothing about deferring makes it harder later.
+
+**The signal to revisit:** external installs, inbound issues from people who are not you, or a fork
+that gets used. Any one of those makes the ask legible. **Revisit sooner** if the D7/D8 vertical
+variants become a commercial product — that is a different question (pricing, not donations) and
+deserves its own entry rather than a sponsor button.

--- a/scripts/build-readme.py
+++ b/scripts/build-readme.py
@@ -63,10 +63,22 @@ def skills(dept):
 
 
 total = sum(len(skills(d)) for d, _, _ in ORDER)
+# Badge counts come from the same tree walk as the tables below, so they cannot drift from
+# reality — a wrong count fails `build-readme.py --check` in CI like any other staleness.
+B = "https://img.shields.io/badge"
 out = [
-    "# headcount",
+    '<h1 align="center">headcount</h1>',
     "",
-    "**Add a department, not a prompt.**",
+    '<p align="center"><b>Add a department, not a prompt.</b></p>',
+    "",
+    '<p align="center">',
+    f'  <a href="https://claude.com/claude-code"><img alt="Built for Claude Code"'
+    f' src="{B}/built%20for-Claude%20Code-D97757?style=flat-square"></a>',
+    f'  <img alt="{len(ORDER)} departments" src="{B}/departments-{len(ORDER)}-3F4B5B?style=flat-square">',
+    f'  <img alt="{total} skills" src="{B}/skills-{total}-3F4B5B?style=flat-square">',
+    f'  <a href="LICENSE"><img alt="MIT licensed" src="{B}/license-MIT-3F4B5B?style=flat-square"></a>',
+    f'  <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="{B}/PRs-welcome-2EA043?style=flat-square"></a>',
+    "</p>",
     "",
     "An agent organization for [Claude Code](https://claude.com/claude-code), structured as a company:",
     f"a chief executive over {len(ORDER)} departments, {total} skills in total.",


### PR DESCRIPTION
First change after going public. Presentation, hardening, and closing out the decision log.

## 🟢 CI is green — and the blackout diagnosis was wrong

This PR's first run **passed all five checks in eight seconds**. The first green run of the project.

Since 28 August every run had failed in 3–4 seconds with no steps and empty output, here and on `main` alike. I diagnosed that as exhausted Actions minutes with the 1 September quota reset as the fix, and said so in this repo's decision log and in earlier PR bodies. The minutes were genuinely exhausted — but **the reset was never the fix.** Actions is free and unlimited for public repositories on standard runners ([GitHub billing docs](https://docs.github.com/en/billing/managing-billing-for-your-products/about-billing-for-github-actions)). Making the repo public under D18 ended the blackout immediately.

The blackout was treated as an external constraint to wait out for a full day, when it was a consequence of a setting this project had already decided to change. D23 records that. `scripts/check-all.sh` was built to decouple verification from CI while it lasted, and earns its place regardless.

## Presentation

The README opens with a centred title, tagline, and badge row — built-for Claude Code, department count, skill count, licence, PRs welcome.

**The counts are generated**, from the same tree walk that builds the department tables, so a badge with a wrong number fails `--check` in CI like any other staleness. Hand-typed counts would have gone stale on the next department — the D19 bug, relocated somewhere more visible.

**`.gitattributes` added.** GitHub had labelled this a *JavaScript* repository on the strength of one `.mjs` guard script, against 101 markdown skills that are the actual product. Linguist counts bytes of code and has no idea what a repository is for.

## Hardening, now that forks can trigger CI

- **`permissions: contents: read`** — the workflow only reads the tree. Being explicit means a permissive account-level default cannot hand a write-scoped token to a fork-triggered run.
- **Push trigger narrowed to `[main]`** — every push was running the workflow twice, once for the push and once for the pull request, on the same commit. The duplicate pairs are visible throughout the run history.
- **Deprecated actions bumped** — the green run warned that `checkout@v4` and `setup-node@v4` run on Node 20, being force-migrated to Node 24. Both now v7, `node-version` 24. **Versions were checked against each action's release page rather than assumed** — the assumption would have been v5, and both are three majors past that.

## Deliberately not done

- **Dependabot** — no dependency manifests exist. It would have nothing to scan.
- **Branch protection requiring approvals** — with a single maintainer, required approvals block the only person who can approve.

## Decision log

| | |
|---|---|
| **D18** | Public under MIT, confirmed via the API. Closes work-queue item 11. Records what publishing did *not* verify — nothing here can run a real marketplace install against a clean client |
| **D19** | Generation widened twice (org-chart table, badge counts) and hardened to discover departments from disk |
| **D20** | Renamed, public, description set, auto-delete enabled, four stale branches gone. Topics outstanding — with the reason they get missed: they are on the About panel, not in Settings |
| **D23** | Presentation + hardening rationale, what was skipped and why, and the corrected CI diagnosis |
| **D24** | Sponsorship deferred — not on principle; one star and no external installs make the ask unevidenced, and it competes with the provenance story for a first-time reader's attention |

## Note

`.gitattributes` is registered to `repo-meta` in this same change. The untracked-file warning in `check-all.sh` caught it before staging — that guard exists because `LICENSE` broke `main` this way in #3, and this is the first time it has fired in anger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_