### PR TITLE
Ignore Python bytecode caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Byproducts of running the check scripts. Nothing here belongs in the repository, and an
+# untracked __pycache__ is enough to make a clean tree look dirty.
+__pycache__/
+*.pyc

--- a/docs/AGENT-SURFACES.md
+++ b/docs/AGENT-SURFACES.md
@@ -109,6 +109,7 @@ plugins/security/**
 
 ```surface:repo-meta
 LICENSE
+.gitignore
 CONTRIBUTING.md
 .gitattributes
 docs/**


### PR DESCRIPTION
Running any of the check scripts under `scripts/` leaves a `__pycache__` directory behind, which is enough to make an otherwise clean working tree report as dirty. Nothing in it belongs in the repository.

**What changed**

- New `.gitignore` covering `__pycache__/` and `*.pyc`.
- `.gitignore` registered to `repo-meta` in `docs/AGENT-SURFACES.md`, the same way `.gitattributes` was — so the surface map stays exhaustive and the surface check keeps passing.

**Verification**

All nine checks pass locally (`scripts/check-all.sh`): surface map, skill frontmatter, provenance, README currency, social card currency, org chart currency, skill references, US English spelling, manifests. `git status` is clean after a full check run, which it was not before.

No generated output changes — 16 departments, 143 skills, unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_