### PR TITLE
Check skill references inside skill bodies

### DIFF
--- a/plugins/finance/skills/tax/SKILL.md
+++ b/plugins/finance/skills/tax/SKILL.md
@@ -52,7 +52,7 @@ owner, and treat it as part of `finance:financial-reporting-and-close`.
 - `finance:capital-allocation` — after-tax returns are the only ones that matter for a decision
 - `people:workforce-planning` — every hire in a new jurisdiction is a tax question before it is a
   cost question
-- `revenue:revenue-recognition` — book and tax treatment diverge, and the difference is itself
+- `finance:revenue-recognition` — book and tax treatment diverge, and the difference is itself
   something to track
 
 ## Never

--- a/scripts/check-skill-refs.py
+++ b/scripts/check-skill-refs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that every `department:skill` reference in the documentation resolves.
+"""Verify that every `department:skill` reference in the repository resolves.
 
 Prose naming specific skills rots as skills are renamed or consolidated — and this repository
 has already consolidated once, losing six capabilities in the process. A reference to a skill
@@ -13,7 +13,14 @@ import os
 import re
 import sys
 
-DOCS = ["README.md", "CONTRIBUTING.md"] + sorted(glob.glob("docs/**/*.md", recursive=True))
+# Skill bodies address each other as often as the prose does, and a rename breaks them the
+# same way. Leaving them out meant the check covered the documentation about the product
+# but not the product, which is where the references a reader follows actually live.
+DOCS = (
+    ["README.md", "CONTRIBUTING.md"]
+    + sorted(glob.glob("docs/**/*.md", recursive=True))
+    + sorted(glob.glob("plugins/*/skills/*/SKILL.md"))
+)
 # `dept:skill` inside backticks — the convention this repository uses for addressing a skill.
 REF = re.compile(r"`([a-z][a-z0-9-]*):([a-z][a-z0-9-]*)`")
 


### PR DESCRIPTION
The reference check covered README, CONTRIBUTING and docs, but not
plugins/*/skills/*/SKILL.md. Skill bodies address each other as often as the
prose does — 92 of the 186 references in the tree live there — and a rename
breaks them the same way. The check covered the documentation about the
product but not the product.

Widening it surfaces one live break: finance:tax pointed at
revenue:revenue-recognition, but that skill sits in finance. The three
neighboring references on the same list are addressed correctly, so this is a
wrong prefix rather than a missing capability.

Verified by reverting the fix and confirming the check now reports it, by
planting a dangling reference in a second skill body, and by confirming a
dangling reference in docs is still caught.
