### PR TITLE
Normalize path separators in the provenance check and chart URLs

### DIFF
--- a/scripts/build-org-chart.py
+++ b/scripts/build-org-chart.py
@@ -92,7 +92,8 @@ def collect():
                 "name": name,
                 "summary": first_sentence(desc),
                 "trigger": desc,
-                "url": f"{BLOB}/{path}",
+                # A GitHub URL is always posix, whatever separator glob handed back.
+                "url": f"{BLOB}/{path.replace(os.sep, '/')}",
             })
         _, title, exec_role = META[slug]
         if slug not in GLYPHS:

--- a/scripts/check-provenance.py
+++ b/scripts/check-provenance.py
@@ -60,7 +60,11 @@ def is_probably_text(path, sniff=4096):
 
 
 problems = []
+# glob returns the platform separator, while SKIP_DIRS and OWN_LICENSE_MENTION are written
+# with forward slashes. On Windows the waiver never matched and this file reported its own
+# license mention as vendored text.
 for path in glob.glob("**/*", recursive=True):
+    path = path.replace(os.sep, "/")
     if not os.path.isfile(path) or path.startswith(SKIP_DIRS):
         continue
     if os.path.abspath(path) == os.path.abspath(__file__):


### PR DESCRIPTION
Both scripts build strings from glob output, which returns the platform
separator. On Linux that is the same character the code assumes; on Windows it
is not, and two checks fail on a clean checkout.

check-provenance.py compares the globbed path against OWN_LICENSE_MENTION,
whose entries are written with forward slashes. The waiver never matched on
Windows, so docs/DECISION-LOG.md was reported as vendored license text — the
one file the waiver exists for. SKIP_DIRS has the same shape and is fixed by
the same normalization.

build-org-chart.py interpolates the globbed path straight into a GitHub blob
URL. A chart generated on Windows carries backslashes in all 143 skill links,
which resolve to nothing. CI is green either way, so the broken chart would
only be visible after it was published.

Verified on Windows: check-all.sh went from two failures to all checks passed,
the regenerated chart is byte-identical to the committed one, and planting a
real vendored license still fails the provenance check while the waived
mentions still pass.
