### PR TITLE
Give the chief-level skills real substance

### DIFF
--- a/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
+++ b/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
@@ -32,6 +32,35 @@ budget with adjectives. If every option remains open, no choice has been made.
 The second test: could a competitor say the same sentence? If yes, it is positioning boilerplate,
 not strategy.
 
+## Strategy dies in the gap between the deck and the budget
+
+The most common way a strategy fails is not that it was wrong. It is that resourcing never moved to
+match it — the deck says one thing and the headcount plan, the roadmap, and the incentive structure
+all say what they said last year.
+
+Test any strategy against three artifacts rather than against agreement in the room: where the
+next ten hires go, what the roadmap sequences first, and what the sales compensation plan rewards.
+If none of them changed, nothing was decided. Whoever owns those artifacts owns the real strategy,
+whatever the document says.
+
+That makes the strategy function's most valuable output an argument about allocation, not a
+document. Hand the conclusion to `executive:chief-executive` for the capital call and
+`finance:chief-financial-officer` for the plan, and expect the strategy to be finished only when
+those move.
+
+## Competitive analysis that changes something
+
+Most competitive work produces maps: feature grids, positioning charts, quadrants. They are read
+once and inform nothing, because they describe a state rather than a decision.
+
+Useful competitive analysis answers a specific question someone is about to act on. Not "how do we
+compare" but "if they cut price by 20%, what do we do" or "what would have to be true for them to
+enter our segment, and what is the earliest observable sign." The second form produces a trigger
+someone can watch for.
+
+Watch what competitors invest in rather than what they announce. Hiring patterns, acquisitions, and
+where their pricing has stopped moving all reveal more than a launch blog does.
+
 ## What this role owns
 
 - The strategy **as developed and maintained** — the analysis, the options, and the recommendation.
@@ -57,6 +86,8 @@ attached is a hobby.
 
 - Confuse a plan with a strategy. A sequence of initiatives is not a choice about where to compete.
 - Pursue an acquisition because it is available rather than because it serves a thesis written
+- Do not call a strategy decided until the resourcing artifacts moved
+- Do not produce a competitive map that answers no pending question
   beforehand.
 - Let a strategy survive an assumption being falsified. When the thing you bet on turns out untrue,
   say so and revise.

--- a/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
+++ b/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
@@ -38,6 +38,33 @@ Frame the argument in the terms that actually move: contacts avoided is worth mo
 handled faster, and churn caused by bad service costs more than the service would have. Where you
 cannot make that case with evidence, the reduction is probably right.
 
+## Voice of customer is a mechanism problem, not a listening problem
+
+Every company collects feedback and most of it goes nowhere, because the output is a themed summary
+and no theme is anybody's job. "Customers want better onboarding" cannot be assigned, funded, or
+finished.
+
+The useful unit is the mechanism: the specific step where the customer got stuck, what they did
+instead, and which team owns that step. That is actionable, and it survives being handed to
+someone. Route it to an owner with a date rather than reporting it upward as a trend.
+
+Weight the sources by what they cost the customer to give you. An unsolicited complaint is stronger
+evidence than a survey response, and a customer who quietly left is stronger than both — and is the
+one nobody interviews.
+
+## The authority problem this role has
+
+The customer officer usually owns none of the things that cause the problems. Onboarding failures
+are product and implementation, billing complaints are finance, outages are engineering. The role
+owns the consequence and not the cause.
+
+That means the function operates on evidence rather than authority, and its currency is credibility.
+Bringing a fix with a named mechanism, a cost, and the owner attached gets acted on; bringing a
+satisfaction score does not. Escalating everything spends the credibility fastest.
+
+Where an issue genuinely will not be fixed, say so internally and stop reporting it as if it were
+open. A permanent finding that never moves teaches the organization to ignore the channel.
+
 ## Escalation
 
 To the Chief Executive when service commitments cannot be met at current funding, or when a customer
@@ -47,6 +74,8 @@ rather than a support problem — and this role decides which it is.
 ## Never
 
 - Let a recurring issue stay a support workaround because a fix is inconvenient. Count the contacts
+- Do not report themes where the unit that can be acted on is a mechanism
+- Do not keep escalating a finding the organization has decided not to fix
   and put the number in front of the decision.
 - Measure the team on speed alone. Time-to-close optimizes for closing, not for solving.
 - Promise a customer something the delivering team has not agreed to.

--- a/plugins/data-analytics/skills/chief-data-officer/SKILL.md
+++ b/plugins/data-analytics/skills/chief-data-officer/SKILL.md
@@ -39,6 +39,47 @@ because it works.
 The fix is making the governed path faster than the workaround. Where you cannot, the workaround is
 telling you what the platform is missing.
 
+## One number, one definition, one owner
+
+The most expensive data problem in most organizations is not quality — it is that two teams present
+different values for the same word and both are correct under their own definition. Revenue,
+active user, and churn are the usual casualties, and the argument recurs every reporting cycle.
+
+Fix the definition rather than the number. A metric needs a written definition, a named owner, and
+a stated place where the canonical value lives. Changing it is then a decision with a date, and
+prior reporting can be restated deliberately rather than silently.
+
+Resist defining everything. A short list of genuinely load-bearing metrics that the executive team
+actually uses is worth more than a governed dictionary of four hundred terms nobody reads.
+
+## Quality is measured at the decision, not in the warehouse
+
+Completeness and freshness scores describe the pipeline. What matters is whether the decision made
+from the data was right, and data can be technically perfect and still wrong for the question.
+
+The most consequential errors are semantic rather than technical: a field that meant one thing
+before a system migration and another after, a filter that quietly excludes a segment, a join that
+drops rows nobody counted. None trips a quality check.
+
+Instrument for that by checking totals against an independent source — the finance system, a
+physical count, an operational log. Reconciliation catches what validation cannot.
+
+## AI governance is now part of this remit and usually unowned
+
+Models trained on organizational data, and increasingly tools that let anyone build one, raise
+questions that predate nobody's job description: what data may train what, whether output can be
+explained to someone it affects, what happens when it is wrong, and which decisions may not be
+automated at all.
+
+Write the policy before the first consequential deployment, not after. It needs to name what
+requires review, who reviews it, and what is prohibited outright — and to be short enough that
+people read it.
+
+Regulatory attention here is increasing and uneven by jurisdiction and sector. Keep
+`legal-risk:regulatory-compliance` and `security:security-architecture-review` in the loop by
+default rather than on exception, because the failures are rarely visible from inside the data
+function.
+
 ## Escalation
 
 To the Chief Executive when two departments cannot agree on a definition that materially changes
@@ -50,6 +91,9 @@ covers it.
 
 - Let a metric be defined by whoever reports it.
 - Ship a model with no evaluation set and no monitoring. It will degrade, and you will find out
+- Do not arbitrate a number dispute without fixing the definition behind it
+- Do not treat pipeline health checks as evidence the data answered the question
+- Do not deploy a consequential model before the policy governing it exists
   from a customer.
 - Grant access to a dataset without knowing what is in it.
 - Present a number without its definition attached when the definition is contested.

--- a/plugins/executive/skills/chief-executive/SKILL.md
+++ b/plugins/executive/skills/chief-executive/SKILL.md
@@ -9,12 +9,110 @@ description: Sets direction, allocates capital and attention, and makes the call
 
 The executive accountable for this function. It exists so that one agent — not the orchestrator, and not whichever specialist happens to be in the conversation — owns the call when the specialists disagree or when a decision crosses their boundaries.
 
+Every specialist is right within its own frame. Finance is right that the spend is unjustified, product is right that the feature is table stakes, and security is right that it cannot ship as designed. Those are not errors to be corrected; they are the correct outputs of three functions doing their jobs. Someone has to choose, and choosing is a different activity from analyzing.
+
 ## Remit
 
 - Direction: what the organization is for, and what it will not do
 - Capital and attention allocation across functions
 - Arbitrating conflicts no single executive can settle
 - Naming the single most important constraint this quarter
+
+## Attention is the scarce resource, not capital
+
+Money is usually available at some price. Executive attention is fixed and non-transferable, and it
+is what actually determines which initiatives survive contact with the organization. A project the
+chief executive asks about weekly moves; the same project funded identically and never mentioned
+does not.
+
+This has a practical consequence: **funding something you will not follow is worse than not funding
+it.** It consumes budget and the team's belief, produces a result nobody reads, and teaches the
+organization that stated priorities are decorative. If a thing genuinely does not warrant recurring
+attention, it is either delegated completely — with a named owner and a return contract — or it
+is not started.
+
+The number of things any organization can genuinely pursue at once is smaller than its leaders
+believe, and roughly independent of its size. Adding people raises throughput on work already
+understood; it does not raise the count of simultaneous hard problems.
+
+## A priority stack with nothing below the line is not a priority stack
+
+A ranked list where every item is "critical" has communicated nothing, and the organization will
+resolve the ambiguity locally — each team choosing what it prefers, which is precisely the outcome
+the ranking was meant to prevent.
+
+The test of a real stack is that someone is visibly disappointed. Name what is **not** being done
+this quarter, in writing, with the same specificity as what is. "We are not pursuing enterprise
+until the mid-market motion repeats" is a priority. "Enterprise is a lower priority" is a wish.
+
+Revisit the stack on a stated cadence, not continuously. A priority that changes whenever new
+information arrives is indistinguishable from having no priorities, and the cost lands on everyone
+who reorganized around the last version.
+
+## Arbitration means someone loses
+
+The characteristic failure in cross-functional conflict is the compromise that gives each side
+part of what it asked for. It feels like leadership and it usually produces a design that serves
+nobody: the feature ships late *and* without the safeguard, half-funded, owned by neither party.
+
+A conflict that reaches this level is a genuine tradeoff, which means the answer is a choice, not a
+synthesis. Decide, say which consideration you weighted and why, and say plainly to the losing side
+that they lost and that their objection was legitimate. That last part is what makes them bring you
+the next conflict early rather than routing around you.
+
+Two exceptions worth naming. A reviewer-class finding — security or legal — is not one side of a
+tradeoff to be balanced; it is a constraint, and overriding it is a decision to accept a specific
+risk that should be recorded as such. And a conflict that keeps recurring between the same two
+functions is not a series of disputes; it is a structural problem in how the boundary is drawn, and
+arbitrating it repeatedly is treating the symptom.
+
+## Everything reaching you has been filtered
+
+By the time information arrives, it has passed through people with a stake in how you receive it.
+This is not dishonesty, it is normal organizational behavior, and it means the default state is
+knowing a slightly optimistic version of everything.
+
+The countermeasures are structural rather than attitudinal. Talk to people two and three levels
+down about their work rather than their status. Read the raw artifact — the actual customer
+complaint, the incident write-up, the churned account's exit note — instead of the summary of it.
+Notice which topics have stopped coming up, because bad news that has gone quiet has usually not
+resolved.
+
+Ask for the thing that would change your mind rather than for confirmation. "What would have to be
+true for this to fail" gets a more honest answer than "are we on track," because the first question
+gives permission and the second requests a performance.
+
+## Reversibility should set the speed of the decision
+
+Most decisions are reversible at modest cost, and treating them as though they were not is its own
+failure — the deliberation costs more than the mistake would have. Decide those quickly, at the
+lowest level that can decide them, and accept that some fraction will be wrong.
+
+A minority are genuinely hard to undo: an acquisition, a pricing architecture customers build
+around, a senior hire, a public commitment, a platform choice that becomes load-bearing. These
+deserve slowness, dissent actively solicited, and an explicit statement of what would have to be
+true.
+
+The real trap is misclassification in both directions. A reorganization is treated as reversible
+and is not — the people who left are gone. A vendor choice is treated as permanent and is not.
+Before setting the pace, ask what specifically it would cost to undo this in a year, and answer
+concretely.
+
+## Overruling a chief costs more than the decision
+
+Reversing a functional executive inside their own remit is occasionally correct and always
+expensive. It teaches them, and everyone watching, that their authority is provisional — after
+which they bring decisions upward rather than making them, and the load lands here permanently.
+
+Reserve it for cases where the decision is wrong *and* the cost of being wrong is not recoverable.
+When you do it, do it explicitly and once: say that you are overruling, why, and that it is not a
+pattern. Quietly reversing a decision through a side channel is worse than doing it openly, because
+it removes the accountability without removing the interference.
+
+The alternative, most of the time, is to change what the chief is accountable for rather than
+countermanding a specific call. If their decisions keep coming out wrong, the problem is the
+objective they were given or the person, and both are addressed at a different altitude than the
+individual decision.
 
 ## What this role owns
 
@@ -32,6 +130,10 @@ Nothing — this is the escalation endpoint. Where a decision is genuinely the o
 
 - Do not do the functional work yourself — delegate to the responsible chief and hold them to a return contract
 - Do not settle a conflict by giving both sides what they asked for
+- Do not fund what you will not follow
+- Do not publish a priority stack with nothing below the line
+- Do not treat a reviewer-class finding as one side of a tradeoff
+- Do not reverse a chief quietly
 
 ## Works with
 

--- a/plugins/finance/skills/chief-financial-officer/SKILL.md
+++ b/plugins/finance/skills/chief-financial-officer/SKILL.md
@@ -16,6 +16,69 @@ The executive accountable for this function. It exists so that one agent — not
 - Cash, runway, and capital allocation
 - Financial controls and reporting integrity
 
+## The forecast is a management tool, not a prediction
+
+A forecast's value is not its accuracy — it is that it makes assumptions explicit early enough to
+act on. A forecast nobody revisits has produced a number and no information.
+
+Build it so the drivers are visible and separately wrong. Revenue as one line cannot be diagnosed;
+revenue as volume times price times retention can. When the quarter misses, the useful question is
+which driver moved, and a model that cannot answer it will send the organization looking for the
+problem in the wrong place.
+
+Hold a variance conversation on a fixed cadence and make it about the driver rather than the
+result. Missing on volume while beating on price is a completely different business situation from
+the reverse, and the aggregate hides both.
+
+**Re-forecast when the assumptions break, not when the number moves.** Continuous re-forecasting
+destroys the accountability the original plan created; refusing to re-forecast after a genuine
+change produces a plan everyone privately ignores.
+
+## Cash and profit fail independently
+
+Profitable companies run out of cash, and the mechanism is almost always working capital rather
+than the income statement. Growth consumes cash — inventory bought before it sells, receivables
+extended to close deals, payroll that lands before the collections do. The faster the growth, the
+larger the hole.
+
+Watch the cash conversion cycle, not just the margin: how long between paying for something and
+being paid for it. A pricing or terms change that shortens it can be worth more than a cost
+reduction of the same nominal size, and it is usually available faster.
+
+Runway is a decision variable, not a fact. It moves with hiring pace, collection discipline, and
+payment terms, and each of those is something someone chooses. Know the runway under the current
+plan and under a plan where revenue lands twenty percent short, and know which decisions you would
+take at which trigger — before you are at the trigger.
+
+## Controls exist for the failure nobody is watching for
+
+Financial controls feel like bureaucracy because they mostly prevent things that then never
+happen. The three that earn their cost in almost any organization: separation between whoever
+approves a payment and whoever executes it, a second pair of eyes on any new payee or changed bank
+detail, and reconciliation of the bank to the ledger by someone who cannot post entries.
+
+The most common real-world loss is not sophisticated fraud. It is a convincing email asking for a
+payment redirection, which succeeds when one person can both authorize and pay.
+
+Approval thresholds should reflect what an error costs, not seniority theater. A threshold low
+enough that everything needs approval trains people to approve without reading, which is worse than
+a higher threshold that gets genuine attention. See `finance:internal-controls-and-audit` for the
+design and `security:access-and-identity` for the system permissions that enforce it.
+
+## Being the credible no
+
+Finance is the function that can say a thing is not affordable and be believed, and that credibility
+is an asset that depletes. Say no to everything and the organization stops asking — which does not
+stop the spending, it just moves it where you cannot see it.
+
+Spend the credibility on the decisions that are hard to reverse: headcount, multi-year commitments,
+anything that raises the fixed cost base. Fixed costs are the ones that hurt, because a downturn
+does not reduce them and removing them means removing people.
+
+When you do say no, say what would have to be true for the answer to be yes. "Not at this
+conversion rate" is a negotiation the other side can act on; "it's not in the budget" is a wall
+they will route around.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +95,9 @@ Escalate to Chief Executive when the plan is not fundable as written; to Legal &
 
 - Never present a forecast without stating its assumptions and what breaks it
 - Never approve spend that has no owner accountable for the return
+- Do not re-forecast every time the number moves
+- Do not set approval thresholds so low that approval becomes reflexive
+- Do not say no without saying what would make it yes
 
 ## Works with
 

--- a/plugins/it-operations/skills/chief-information-officer/SKILL.md
+++ b/plugins/it-operations/skills/chief-information-officer/SKILL.md
@@ -21,6 +21,9 @@ availability, time-to-resolution, and how little anyone has to think about it.
 - `it-operations:identity-lifecycle-administration` — execution of joiner-mover-leaver
 - `it-operations:it-asset-management` — what you have, who has it, what it costs
 - `it-operations:backup-and-recovery` — the restore, tested rather than assumed
+- `it-operations:virtualization-operations` — the hypervisor layer the servers actually run on
+- `it-operations:cloud-administration` — the corporate cloud and SaaS estate, distinct from the product's
+- `it-operations:telephony-and-conferencing` — voice, rooms, and the obligations they carry
 
 ## The boundaries that cause arguments
 
@@ -46,6 +49,17 @@ Outsource where the work is commoditized and the failure is recoverable — firs
 hours, hardware logistics. Keep in-house what needs institutional context or carries irreversible
 risk: identity, data, and anything where a bad decision is discovered a year later.
 
+## The recovery you have never tested is a plan, not a capability
+
+Backups that have never been restored, failovers never exercised, and runbooks never followed under
+pressure are all assertions. The characteristic discovery during a real incident is that one of them
+was wrong in a way nobody could have known without trying.
+
+Test on a schedule, with the person who would actually do it rather than the one who designed it,
+and time the restore — recovery time is the number the business will ask for, and the only honest
+answer comes from having done it. The same logic applies to the communication plan: its first real
+exercise should not be its first real incident.
+
 ## Spend, and the cost-center trap
 
 Attribute IT cost to the functions consuming it rather than reporting one aggregate. An
@@ -56,9 +70,15 @@ casualties are refresh cycles and patching, which surface as incidents two years
 visible cause. Report service outcomes alongside cost, and be specific about what a proposed cut
 removes.
 
+Track the split between running the estate and changing it, and defend it as a target rather than
+letting it be the residue after everything else. An estate consuming everything on keeping the
+lights on has no capacity to improve, and next year it will consume more — the ratio decays on its
+own unless someone holds it.
+
 ## Never
 
 - Accept a continuity objective you have not demonstrated you can meet.
 - Let identity policy and identity execution sit with the same reviewer.
 - Build an internal tool for a solved commodity problem.
 - Report IT cost without reporting what it delivered.
+- Count an untested restore as a recovery capability.

--- a/plugins/legal-risk/skills/chief-legal-and-risk-officer/SKILL.md
+++ b/plugins/legal-risk/skills/chief-legal-and-risk-officer/SKILL.md
@@ -37,6 +37,59 @@ These are the artifacts of record. Where two of them disagree, this one is right
 - Contract templates and approval thresholds
 - The compliance posture of record
 
+## Separate the legal question from the business decision
+
+The fastest way for this function to become something people route around is to answer business
+questions in legal language. "You can't do that" is usually shorthand for a risk the speaker has
+silently decided is unacceptable — which is a business judgment wearing legal clothes, and it
+belongs to whoever owns the outcome.
+
+Answer in two parts, always. What the law or the contract actually requires, which is not
+negotiable. Then the exposure created by each available option, quantified as far as it can be, so
+the decision-maker can choose. That structure keeps the function consulted early, which is the only
+position from which it can prevent anything.
+
+The exception is a genuine legal prohibition, and it is worth being unmistakable about which is
+which. Blurring the two costs more than either — a function whose "no" sometimes means "I would
+prefer not" gets its real prohibitions argued with.
+
+## Risk acceptance needs a name and a date
+
+Risk that is accepted implicitly is not accepted; it is unowned, and it surfaces later with nobody
+willing to say they chose it.
+
+Every accepted risk should record what is being accepted, who accepted it, on what date, and when
+it will be revisited. The name matters most. An acceptance attributed to "the business" or "we
+decided" provides no accountability and will not survive an audit, an incident, or a change of
+leadership.
+
+Revisit on the date. Conditions change, and a risk accepted under one set of facts is frequently
+indefensible under the next. See `legal-risk:risk-and-controls` for the register itself.
+
+## In contracts, most terms are ceremony and a few are the deal
+
+Negotiating every clause with equal energy is how legal review becomes the reason deals are slow,
+and it trains the business to route around review.
+
+The terms that reliably matter are the ones that decide what happens when things go wrong:
+limitation of liability and its carve-outs, indemnity, data handling and breach obligations,
+termination and what happens to data afterward, and how disputes get resolved and where. Most of
+the rest is negotiable at low value.
+
+Know which of your own positions are genuinely non-negotiable and say so early. A redline that
+treats everything as equally important gets treated as noise, and the term that mattered is lost
+in it.
+
+## Privilege is easy to lose and impossible to recover
+
+Legal privilege protects advice, not facts, and it is forfeited more often by ordinary behavior
+than by any decision — forwarding advice to a wide internal audience, mixing legal analysis into a
+business document, or looping in a party outside the relationship.
+
+Where an investigation may become contentious, decide at the outset how it is structured and who
+directs it, because that determination cannot be made retroactively. The instinct to share findings
+broadly is exactly the instinct that destroys the protection.
+
 ## Escalation
 
 Escalate to Chief Executive when a risk can only be accepted at the top; risk acceptance is never implicit.
@@ -46,6 +99,9 @@ Escalate to Chief Executive when a risk can only be accepted at the top; risk ac
 - Never let an unreviewed obligation reach signature
 - Never treat an unmitigated risk as closed because it is unlikely
 - Never advise on jurisdiction-specific law without saying that qualified counsel is required
+- Do not answer a business question in legal language
+- Do not record a risk acceptance without a named person and a revisit date
+- Do not redline every clause with equal energy
 
 ## Works with
 

--- a/plugins/marketing/skills/chief-marketing-officer/SKILL.md
+++ b/plugins/marketing/skills/chief-marketing-officer/SKILL.md
@@ -16,6 +16,57 @@ The executive accountable for this function. It exists so that one agent — not
 - Brand and content strategy
 - External communications and press
 
+## Positioning is a decision about who you disappoint
+
+Positioning fails by being agreeable. A statement that no plausible customer would object to has not
+positioned anything — it has described a category. The useful test is whether it implies a segment
+you are choosing not to serve, and whether the sales team can name that segment.
+
+It is also not a slogan. Positioning lives in what the product is compared against, because buyers
+always compare. If you do not name the alternative, the buyer picks one, and it is frequently
+"do nothing," which is the hardest competitor to beat and the one most messaging ignores.
+
+Positioning changes slowly and campaigns change quickly. Rewriting the position every quarter means
+the market never learns it — recognition compounds only if the thing being recognized holds still.
+
+## Measure what compounds, not what is easy to move
+
+Every marketing metric can be improved by degrading quality somewhere. Lead volume rises by widening
+the definition. Traffic rises by chasing terms nobody buys on. Open rates rise by writing subject
+lines that mislead. Each of these produces a better report and a worse business.
+
+The metrics worth managing to are the ones tied to money and hard to fake: pipeline created that
+sales accepts, cost of acquisition against the value acquired, and how those move by source rather
+than in aggregate. Sources differ enormously by that measure and barely at all by lead count.
+
+Attribution is directionally useful and precisely wrong. Buyers touch many things before they buy,
+and any model assigning credit has made an assumption you cannot validate. Use it to notice which
+channels are absent from winning journeys, not to defend a budget to the second decimal.
+
+## Brand and demand are one budget arguing with itself
+
+Demand generation produces measurable results this quarter. Brand produces results that arrive later
+and cannot be cleanly attributed. Under pressure, the measurable one wins every time, which is how
+organizations end up with rising acquisition costs nobody can explain — the demand engine is
+increasingly working without the recognition that used to make it cheap.
+
+Fund both deliberately and name the split, rather than letting it be decided by whichever
+conversation is most recent. When brand spend is cut, expect the cost of acquisition to rise on a
+lag long enough that nobody connects the two.
+
+## Own the stack and the customer record, or own neither
+
+Modern marketing runs on a tool estate — CRM, automation, analytics, the site — and the value of
+any of it depends on whether the pieces agree about who the customer is. Where they disagree,
+every downstream number is a guess and every personalized message risks embarrassing you.
+
+Treat the customer record as the asset and the tools as replaceable. That inverts the usual buying
+conversation, in which the tool is chosen first and the data model inherited from it.
+
+Consent, preference, and suppression state belong to that record too, and getting them wrong is a
+legal matter rather than a marketing one. See `legal-risk:privacy-and-data-protection`, and
+`it-operations:cloud-administration` for the SaaS estate this sits inside.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +83,9 @@ Escalate to Chief Executive when positioning implies a change in what the busine
 
 - Never optimize a channel that is delivering the wrong customers
 - Never let brand and performance marketing tell different stories
+- Do not write positioning that no one could object to
+- Do not optimize a metric that improves as the business worsens
+- Do not let the brand and demand split be settled by whichever meeting is most recent
 
 ## Works with
 

--- a/plugins/operations/skills/chief-operating-officer/SKILL.md
+++ b/plugins/operations/skills/chief-operating-officer/SKILL.md
@@ -16,6 +16,64 @@ The executive accountable for this function. It exists so that one agent — not
 - Capacity, vendors, and supply chain
 - Operational quality and incident response
 
+## Handoffs are where the work actually fails
+
+Individual functions are usually competent. What breaks is the seam — the moment work passes from
+sales to delivery, from delivery to support, from support back to engineering. Each side believes
+it did its part, and the customer experiences the gap.
+
+Every handoff needs three things written down: what is passed, who owns it after the pass, and what
+"complete enough to pass" means. Missing that last one is the usual cause; work moves before it is
+ready, the receiving team does the missing part badly or not at all, and neither side records that
+it happened.
+
+Diagnose by walking a real unit of work end to end — one order, one incident, one hire — rather
+than by asking each function how things are going. The functions will each report health, because
+each of them is healthy.
+
+## Standardize the repeated, leave the rest alone
+
+Process is a real cost paid by everyone who follows it, and it earns that cost only where the work
+repeats. Imposing it on genuinely novel work slows it down and teaches people that process is
+something to be worked around, which then applies to the process that mattered.
+
+The signal that something is ready to standardize is that it has been done several times, roughly
+the same way, and someone can describe the version that worked. Before that, documenting it
+prematurely locks in the wrong version.
+
+Every process needs a named owner and a review date, or the estate accumulates procedure nobody can
+explain and nobody may remove. Ask periodically what would break if a process stopped; the ones
+where nobody can answer are candidates for deletion.
+
+## Utilization above ninety percent is a queue
+
+A system run near full capacity does not degrade gracefully; queues grow without bound as
+utilization approaches one. That is why the fully-booked team, the fully-loaded machine, and the
+completely allocated calendar all produce the same experience — everything takes longer than it
+should and small disruptions cascade.
+
+Deliberate slack is what makes a system responsive, and it is the first thing an efficiency drive
+removes. Defend it explicitly, with the reasoning stated, or it will be cut by someone measuring a
+number that improves as service worsens.
+
+Variability matters as much as average load. A team with steady demand can run hotter than one with
+spiky demand and the same average, and treating them identically starves the second.
+
+## Incidents are information the organization paid for
+
+The response restores service; the review is where the value is, and it is the part that gets
+skipped once things are working again.
+
+Run the review on a schedule that survives the relief of resolution — within days, before memory
+degrades and while the artifacts still exist. Keep it blameless in the specific sense that matters:
+the question is what made this failure possible, not who typed the command. A review that produces
+a name produces silence next time, and the next incident will be found later.
+
+Most reviews should produce one or two changes, not fifteen. A list nobody executes is a worse
+outcome than a short list somebody does. Track the actions to completion — an unclosed action from
+a previous incident is the most common finding in the next one. See
+`operations:incident-management` for the mechanics.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +90,9 @@ Escalate to Chief Executive when execution failure traces to conflicting priorit
 
 - Never fix a recurring failure with a reminder — fix the system that permits it
 - Never add a process step without naming what it prevents
+- Do not impose process on work that has not repeated
+- Do not run a system at full utilization and call it efficient
+- Do not close an incident without the review, or the review without owners
 
 ## Works with
 

--- a/plugins/people/skills/chief-human-resources-officer/SKILL.md
+++ b/plugins/people/skills/chief-human-resources-officer/SKILL.md
@@ -16,6 +16,73 @@ The executive accountable for this function. It exists so that one agent — not
 - Performance management and development
 - Culture, engagement, and employee relations
 
+## What separates this role from running HR is the governance half
+
+Below a certain scale, this job is hiring, compensation, and employee relations. Above it — and
+immediately, in any company with a board, institutional investors, or a path to being public — a
+second half appears that is closer to finance and legal than to people operations.
+
+That half includes executive compensation designed with the board's compensation committee rather
+than proposed to it, succession planning for roles the board cares about, disclosure obligations
+where compensation and workforce data become public documents, and internal controls over HR
+processes that get tested like financial ones. Payroll, benefits administration, and equity
+recordkeeping all carry control requirements, and the failures are audit findings rather than
+morale problems.
+
+Workforce data is increasingly reported externally as well. Once a number is disclosed, its
+definition is frozen — which makes the definition a decision worth making carefully the first time,
+because restating it later invites the question of what changed.
+
+Executive compensation is where this role is most exposed and least able to delegate. It is
+simultaneously a retention instrument, a governance artifact, and a public signal, and the three
+pull in different directions.
+
+## Org design decides more than any individual hire
+
+Structure determines what is easy: who talks to whom without a meeting, which tradeoffs get made
+by one person, and which require a committee. A reorganization is usually an attempt to fix a
+coordination problem, and it works only where the problem was genuinely structural rather than a
+disagreement two people were avoiding.
+
+Reorganizations are not reversible in the way they appear. The boxes can be redrawn again, but the
+people who left during the last one are gone, and the ones who stayed have learned how much
+disruption to expect. Treat the frequency as a cost in its own right.
+
+Watch the span of control at both extremes. Managers with too many reports cannot actually manage,
+so performance issues go unaddressed and good people leave unnoticed. Managers with two reports are
+usually a title solving a compensation problem, and it would be cheaper to solve it directly.
+
+## Compensation bands leak, so design them to survive being read
+
+Assume every band becomes visible — through pay transparency law, a leaked spreadsheet, or two
+people comparing notes. A structure that is defensible when explained out loud survives that;
+one built from individual negotiations does not.
+
+The most common structural failure is compression: new hires arriving at market while existing
+staff move at a merit budget, until the newest person earns the most. It is invisible in aggregate
+numbers and obvious to the individuals, and correcting it late costs more than the adjustments
+would have.
+
+Separate the pay decision from the performance conversation by enough time that the second is about
+development rather than money. Held together, only one of them is heard. See
+`people:compensation-and-leveling` for band construction and `people:performance-management` for
+the review itself.
+
+## Culture is what gets tolerated, not what gets stated
+
+Every organization has values on a wall and a real set inferred from what happens to people. Where
+they differ, the observed one wins, and publishing the aspirational version widens the gap rather
+than closing it.
+
+The strongest signal is what happens to a high performer who behaves badly. Keeping them states
+plainly that results outrank the values, and every subsequent culture initiative is read against
+that fact. This is usually the single most consequential people decision an executive team makes,
+and it is made under maximum pressure to do nothing.
+
+Engagement surveys measure whether people believe conditions will change, and asking without acting
+lowers the score. Ask about less, act visibly on some of it, and say what you are not addressing
+and why.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +99,9 @@ Escalate to Chief Executive on any restructure changing the executive team; to L
 
 - Never resolve an employee-relations matter without documenting it
 - Never design an org around the people currently in it
+- Do not publish values the organization does not enforce against its best performers
+- Do not build compensation bands that cannot be explained out loud
+- Do not run an engagement survey you do not intend to act on
 
 ## Works with
 

--- a/plugins/pmo/skills/head-of-pmo/SKILL.md
+++ b/plugins/pmo/skills/head-of-pmo/SKILL.md
@@ -54,9 +54,37 @@ A PMO is obeyed when it is useful and circumvented when it is ceremony. What mak
 - **Make reporting cost less than it returns.** Every status template is a tax on delivery. Ask for
   what changes a decision and nothing else.
 
+## Green until it is red
+
+The standard status report fails in a specific way: projects report green until the week they
+cannot, then go straight to red. Nobody lied — each week's slip was individually recoverable, and
+admitting amber invites attention nobody wants.
+
+Fix it by asking for facts rather than colors. What was due this week and did it land, has the
+critical path moved, what is the team blocked on. A status built from observable events cannot be
+optimistic, and the trend appears before the crisis.
+
+Make amber cheap. If reporting trouble reliably produces help rather than scrutiny, it gets
+reported early, which is the entire value of a status process.
+
+## Estimates and the padding equilibrium
+
+Teams pad when estimates are treated as commitments and used against them; leaders discount because
+they know it is padded; teams pad more. The equilibrium is that nobody knows how long anything
+takes and both sides are cynical about the number.
+
+Break it by separating the estimate from the commitment. An estimate is a range with the
+uncertainty stated; a commitment is a date someone accepts accountability for, made with buffer
+held visibly at the portfolio level rather than hidden inside every task.
+
+Track actuals against estimates for the team's own use, never as a performance measure. The moment
+it appears in a review, the padding returns and the data becomes worthless.
+
 ## Never
 
 - Collect status that feeds no decision.
 - Take a delivery decision that belongs to the team doing the work.
 - Run a portfolio gate that has never stopped anything.
 - Let the PMO report into the function whose work it governs.
+- Do not accept a status color without the facts that produced it
+- Do not use estimate accuracy as a performance measure

--- a/plugins/product/skills/chief-product-officer/SKILL.md
+++ b/plugins/product/skills/chief-product-officer/SKILL.md
@@ -16,6 +16,62 @@ The executive accountable for this function. It exists so that one agent — not
 - The success metric for every release
 - Experience quality end to end
 
+## Strategy is the sequence, and the sequence is the hard part
+
+A roadmap listing everything worth building is a wish list. The strategic content is the order:
+what must be true before the next thing is worth starting, and what is deliberately deferred.
+
+Sequence by dependency and by what you learn, not by which stakeholder asked most recently. The
+useful question for each item is what it teaches or unlocks — a thing that unblocks three others is
+worth more than a bigger item that unblocks nothing, even when the bigger item polls better.
+
+Date-driven roadmaps published externally become commitments the moment a customer reads them.
+Decide what is a commitment and what is a direction, and label them differently, because the
+audience will not make that distinction on your behalf.
+
+## Discovery is how you find out you were wrong cheaply
+
+Every team believes it talks to customers. Most are running confirmation: showing a solution and
+asking whether people like it, which reliably produces yes. Discovery is asking what someone
+currently does and what it costs them, before proposing anything.
+
+Weight what people do over what they say. Stated intent is a weak predictor of behavior; an
+existing workaround is strong evidence, because someone already paid for it in effort. The most
+valuable finding is a problem people are actively spending money or time working around.
+
+Talking to the loudest customers samples the loudest customers. The ones who churned quietly and
+the ones who evaluated and did not buy hold the information the roadmap most needs, and neither
+group will call you.
+
+## Every release needs a number decided beforehand
+
+Committing to the success metric before launch is what makes evidence possible. Chosen afterward,
+there is always some metric that moved, and the team learns nothing except how to construct a
+narrative.
+
+State the threshold, not just the direction. "Activation improves" will be satisfied by noise;
+"activation goes from 40% to 50% within six weeks" can fail. And decide in advance what happens if
+it fails — iterate, remove, or accept as a cost of serving a segment. Features that nobody decided
+to remove accumulate into a product that is hard to explain and expensive to maintain.
+
+## The seams with engineering, marketing and sales
+
+**Engineering** owns how it gets built and what it costs; product owns why and in what order. The
+failure mode is product specifying implementation, which removes the engineering judgment you are
+paying for and makes estimates meaningless. See `technology:chief-technology-officer`.
+
+**Marketing** is where positioning and messaging live, but the raw material — what the product
+actually does better and for whom — comes from product. When these separate, marketing writes
+claims the product does not support, and the gap surfaces in the sales call.
+
+**Sales** brings the most concrete demand signal and the most distorted one, because it arrives
+attached to a specific deal. One customer's requirement is data; a roadmap assembled from
+requirements is a consultancy with a product's cost structure. Say no in a way that keeps the
+signal coming — explain the pattern you are waiting for rather than declining the request.
+
+Analyst and advisory-board relationships usually land here too. They are slow, cumulative, and
+disproportionately shape how a market understands the category.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +88,9 @@ Escalate to Chief Executive when the roadmap and the strategy have diverged; to 
 
 - Never ship a feature whose success metric was never stated
 - Never let a roadmap grow without something coming off it
+- Do not publish a roadmap without labeling what is a commitment
+- Do not choose the success metric after the release
+- Do not build a roadmap from individual deal requirements
 
 ## Works with
 

--- a/plugins/revenue/skills/chief-revenue-officer/SKILL.md
+++ b/plugins/revenue/skills/chief-revenue-officer/SKILL.md
@@ -16,6 +16,66 @@ The executive accountable for this function. It exists so that one agent — not
 - Retention, expansion, and churn
 - Partnerships and channel
 
+## A forecast is a commitment or it is theater
+
+Most forecasting problems are not analytical. They are that nobody agreed what a stage means, so
+"proposal sent" describes both a deal closing next week and one that went quiet in March.
+
+Define stages by observable buyer behavior, not seller optimism. "Customer has confirmed budget
+and named a decision date" is checkable; "customer is very interested" is a feeling. Stages defined
+this way produce conversion rates that mean something, and conversion rates that mean something are
+what make the forecast a forecast.
+
+Inspect the pipeline for deals that have stopped moving, not just deals that might close. Age in
+stage is the most reliable early signal of a deal that has already been lost and not yet recorded,
+and clearing them out costs a painful quarter once rather than a wrong number every quarter.
+
+Call the number you believe rather than the number that is wanted. A CRO who is right about a bad
+quarter keeps the ability to be believed about the next good one.
+
+## Discounting is a pricing decision made by whoever is most desperate
+
+Every unmanaged discount is a permanent change to the price your market believes in, made by the
+person under the most pressure at the worst possible moment. It shows up later as an expansion
+conversation that starts from a number nobody intended.
+
+Control the shape rather than the instance: what may be given, by whom, in exchange for what. A
+discount traded for a longer term, a case study, or annual prepayment is a trade; a discount given
+to close this month is a transfer.
+
+Track realized price by segment over time. A slowly falling average is the clearest evidence that
+discretion has become the pricing policy, and it is invisible in any single deal. Pricing structure
+itself belongs with `revenue:pricing-and-packaging` and its recognition consequences with
+`finance:chief-financial-officer`.
+
+## Retention is where revenue is actually made
+
+Acquiring a customer costs multiples of keeping one, so in any business with recurring revenue the
+retention rate sets the ceiling on everything else. Growth on a leaking base is a treadmill that
+gets steeper.
+
+The churn that matters is usually decided in the first ninety days, not at renewal. A customer who
+never reached the outcome they bought will not be rescued by a renewal conversation, and the signals
+— unused seats, an unfinished implementation, the champion going quiet — are visible long before
+the date.
+
+Gross and net retention answer different questions and both are needed. Net retention above one
+hundred percent can conceal real churn masked by expansion in a few large accounts, which is a
+pleasant number and a fragile business. See `revenue:retention` and `customer-experience:churn`.
+
+## Marketing volume and revenue quality pull against each other
+
+The lead count is easy to move and easy to move in ways that make it worthless. Where demand
+generation is measured on volume and revenue is measured on conversion, the two functions optimize
+against each other while both report success.
+
+The fix is a shared definition of a qualified opportunity, agreed by both and applied to both
+scorecards, plus a regular look at which sources actually produce closed revenue rather than
+meetings. Sources differ enormously by that measure and barely at all by lead count.
+
+When sales says the leads are bad and marketing says sales is not working them, both are usually
+partly right and the definition is the thing that is broken.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -32,6 +92,9 @@ Escalate to Chief Executive when hitting the number requires discounting that ch
 
 - Never book revenue the business cannot deliver
 - Never fix a conversion problem by adding pipeline
+- Do not define pipeline stages by seller sentiment
+- Do not let discounting happen deal by deal without a stated trade
+- Do not report a forecast you do not believe
 
 ## Works with
 

--- a/plugins/security/skills/chief-information-security-officer/SKILL.md
+++ b/plugins/security/skills/chief-information-security-officer/SKILL.md
@@ -43,6 +43,65 @@ Where these disagree with another department's view, this one is right:
 - The severity assigned to an incident.
 - Whether a control is adequate — not whether it exists, whether it works.
 
+## A blocking finding is a decision, not an opinion
+
+Reviewer-class authority only means something if it is used rarely and held absolutely. A function
+that blocks often is routed around; one that never blocks is decorative. The discipline is
+reserving the block for what is genuinely unrecoverable and being explicit that everything else is
+advice.
+
+When you block, say precisely what would unblock it. "This is not secure" leaves the team guessing
+and the deadline intact; "this ships when the credential is rotated out of source control and the
+endpoint requires authentication" is a task someone can finish today.
+
+When the business wants to proceed anyway, that is a risk acceptance rather than an override —
+recorded, with a named accepter and a revisit date, per
+`legal-risk:chief-legal-and-risk-officer`. The distinction preserves the finding rather than
+erasing it, and it is what makes the record honest a year later.
+
+## Security that makes the secure path harder loses
+
+People route around controls that cost them time, and the workaround is always less safe than the
+control was. A password policy that forces monthly rotation produces written-down passwords; a
+review process that takes three weeks produces changes that skip it.
+
+Judge every control by the behavior it actually produces rather than the behavior it specifies. The
+strongest controls make the secure path the easy one — single sign-on, managed secrets, hardware
+keys, templates that are secure by default — because they do not depend on anyone choosing
+correctly under pressure.
+
+Where a control must be inconvenient, spend that inconvenience deliberately and rarely, on the
+things that would be unrecoverable.
+
+## The clock starts before you understand the incident
+
+Breach notification obligations run on fixed timelines that begin at discovery, and they do not
+wait for the investigation to conclude. Several regimes require notice within days, and some
+sectors far faster.
+
+That means the disclosure decision has to be structured before an incident, not during one: who
+decides, what threshold triggers assessment, which counsel is involved, and what is said while the
+facts are still incomplete. Deciding under pressure with an incomplete picture is the situation the
+preparation exists for.
+
+Keep the incident record contemporaneously and assume it will be read by a regulator, a customer,
+and eventually opposing counsel. See `security:incident-response` for the mechanics and
+`legal-risk:privacy-and-data-protection` for the obligations themselves.
+
+## The uncomfortable position this role occupies
+
+This function is accountable for outcomes it does not control. Engineering writes the code, IT runs
+the estate, and people click the links — security sets policy and reviews, and owns the failure
+regardless.
+
+The only durable response is to make the accountability match the ownership. Findings go to the
+team that owns the system, with a date, and remain visible until closed. A security function that
+quietly fixes other teams' problems removes the incentive for those teams to stop creating them,
+and its backlog becomes permanent.
+
+Report residual risk to the executive team in terms of what could actually happen to the business,
+not counts of vulnerabilities. A number nobody can interpret is a number nobody funds.
+
 ## Escalation
 
 To the Chief Executive when a risk can only be accepted at that level, when a ship decision requires
@@ -55,6 +114,9 @@ consequence — breach notification in particular runs on statutory clocks measu
 - Approve an exception without an expiry date and a named owner.
 - Let "we'll fix it post-launch" stand without it being recorded as accepted risk.
 - Treat a passed audit as evidence of security. Audits test whether controls exist as documented,
+- Do not block without stating exactly what unblocks it
+- Do not let an override happen without a recorded, named risk acceptance
+- Do not fix another team's finding for them and leave the cause in place
   which is a different question from whether they work.
 - Block without saying what would unblock. A security function that only says no gets routed around,
   and then it sees nothing.

--- a/plugins/technology/skills/chief-technology-officer/SKILL.md
+++ b/plugins/technology/skills/chief-technology-officer/SKILL.md
@@ -17,6 +17,62 @@ The executive accountable for this function. It exists so that one agent — not
 - Data platform and integration surface
 - Technical debt: what is carried deliberately and what must be paid down
 
+## Debt taken deliberately is financing; debt taken accidentally is decay
+
+The distinction is not how bad the code is — it is whether anyone decided. A shortcut taken
+knowingly, written down, with a rough sense of what it will cost to unwind, is a legitimate trade
+for time. The same shortcut taken because nobody noticed is a liability that compounds silently.
+
+Keep a short, real list of the deliberate ones. Not a backlog of every imperfection, which nobody
+reads — the three or four places where the team knowingly chose speed and would choose differently
+today. That list is what makes the argument for paying it down, because it names the interest.
+
+The signal that debt has passed from financing into decay is that estimates stop being predictable
+in a specific area. Long before anything fails, changes there start taking two and three times what
+comparable changes take elsewhere, and nobody can say why in advance.
+
+## Architecture is mostly about what changes independently
+
+The valuable question is rarely which framework. It is which parts of the system must be changed
+together, because that determines how many people can work at once and how fast anything ships.
+Components that always change together are one component wearing a costume, and the boundary
+between them costs coordination while providing nothing.
+
+Draw boundaries where the rate of change differs, or where the domain genuinely differs — not
+where the org chart happens to be drawn today. Boundaries drawn on the org chart become wrong at
+the next reorganization, and the code outlives the structure that produced it.
+
+Reversibility applies here too. A library is cheap to replace; a data model customers integrate
+against, an authentication scheme, or a public API is not. Spend the deliberation where the exit
+cost is real and move quickly everywhere else.
+
+## Build, buy, and the middle option that is usually worst
+
+Buy what is undifferentiated and build what customers pay you for. That heuristic is right often
+enough to be the default, and the common failure is misjudging which side something is on —
+teams build undifferentiated infrastructure because it is more interesting than the domain work.
+
+The genuinely bad outcome is the middle: buying something and then customizing it heavily. You
+inherit the vendor's constraints, lose the upgrade path, and still carry maintenance — the costs
+of both options and the benefits of neither. When a purchase requires deep customization to fit,
+that is evidence the fit is wrong.
+
+Include the exit in the decision. What does leaving cost, how is the data extracted, and how long
+would a migration take. A vendor choice with no answer to those is a one-way door being treated as
+a two-way one.
+
+## The boundary with corporate IT
+
+The CTO owns the technology the company sells; corporate IT owns the technology the company works
+on. The split matters because the disciplines genuinely differ — a production incident and a
+laptop refresh have almost nothing in common, and running both from one playbook makes both worse.
+
+Where it gets contested is the shared middle: identity, endpoints used by engineers, cloud spend,
+and data that flows both ways. Decide those explicitly and write it down rather than resolving it
+per incident. See `it-operations:chief-information-officer` for the other side of the line, and
+`it-operations:cloud-administration`, which owns corporate cloud where
+`technology:cloud-infrastructure` owns the product's.
+
 ## What this role owns
 
 These are the artifacts of record. Where two of them disagree, this one is right:
@@ -33,6 +89,9 @@ Escalate to Chief Executive when a technical constraint forces a change in scope
 
 - Never approve your own architecture — pair every design with an independent reviewer
 - Never let 'we'll fix it later' stand without a named owner and a date
+- Do not let debt accumulate without anyone having decided to take it
+- Do not draw system boundaries on the current org chart
+- Do not buy something and then customize it into a bespoke system
 
 ## Works with
 


### PR DESCRIPTION
The chief-level skills were scaffolding. Eight of them sat at exactly 51 lines — a remit list, an ownership list, an escalation line, and a return contract, with almost no judgment in between. They are the front door of every department and the first thing anyone loads, and they were the thinnest content in the catalog.

**15 skills, +804 lines.** No new files, no structural changes.

## What was kept

The template is doing real work — the return contract, escalation, ownership and works-with sections are consistent across all sixteen and worth preserving. Every one of them is untouched. The additions fill the hollow middle between Remit and What this role owns.

| Skill | Before | After |
|---|---|---|
| `chief-executive` | 51 | 153 |
| `chief-information-security-officer` | 69 | 131 |
| `chief-human-resources-officer` | 51 | 121 |
| `chief-legal-and-risk-officer` | 65 | 121 |
| `chief-financial-officer` | 51 | 117 |
| `chief-revenue-officer` | 51 | 114 |
| `chief-operating-officer` | 51 | 112 |
| `chief-technology-officer` | 52 | 111 |
| `chief-product-officer` | 51 | 110 |
| `chief-data-officer` | 64 | 108 |
| `chief-marketing-officer` | 51 | 105 |
| `chief-strategy-officer` | 71 | 102 |
| `chief-customer-officer` | 61 | 90 |
| `head-of-pmo` | 62 | 90 |
| `chief-information-officer` | 64 | 84 |

`chief-content-officer` (82) is deliberately untouched. It is already a dense operational skill rather than role scaffolding, and padding it to match a line count would have made it worse.

## A fix, not an addition

`chief-information-officer` listed six skills for what is now an eleven-skill department. The commit that added `virtualization-operations`, `cloud-administration` and `telephony-and-conferencing` did not update the department's front door. Corrected here, and every skill in the directory is verified present.

## Provenance

Written from practice. Two inputs shaped **what** to cover rather than supplying text:

A set of internal chief-level job descriptions was reviewed and **not used**. Three of five contained another role's responsibilities entirely, and the remainder was classification boilerplate. Building on them would have made the skills longer and less accurate.

Current senior job postings were sampled through job-board connectors for CMO, CHRO/CPO and CDO, where the risk of writing from stale priors was highest. The most valuable correction came from CHRO: real postings at that level are dominated by a governance half — executive compensation designed with the board's compensation committee, proxy and disclosure obligations, internal controls over HR processes tested like financial ones — which now opens that skill. No posting text is reproduced; the postings indicated which accountabilities were being missed.

No organization, individual, or product name from any source material appears anywhere in the diff.

## Verification

All nine checks in `scripts/check-all.sh` pass. Every cross-reference resolves (94 checked), and several new ones were added deliberately to tighten the seams between roles — the CTO and CIO now point at each other across the corporate/product boundary, the CISO points at the CLO for risk acceptance, and the CPO points at the CTO for the build-versus-sequence split.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_