### PR TITLE
Never coverage on all 146 skills, and named software tools on 28

### DIFF
--- a/plugins/corporate-strategy/skills/portfolio-strategy/SKILL.md
+++ b/plugins/corporate-strategy/skills/portfolio-strategy/SKILL.md
@@ -54,6 +54,13 @@ allocation you already had.
 
 Force a ranking. Tiers are how everything stays funded.
 
+## Never
+
+- Fund a line because it is large. Fund it on marginal return.
+- Keep a line alive on sunk cost.
+- Starve a line without deciding to exit it. Slow starvation costs more than a clean exit.
+- Review the portfolio only when a line is already in trouble.
+
 ## Return contract
 
 Each line with its posture and evidence, the recommended allocation and what changed from last

--- a/plugins/corporate-strategy/skills/strategic-alliances/SKILL.md
+++ b/plugins/corporate-strategy/skills/strategic-alliances/SKILL.md
@@ -59,3 +59,10 @@ strategy moved.
 
 Say it plainly and early. Partnerships die quietly for a year before anyone admits it, and that year
 is the cost.
+
+## Never
+
+- Sign a partnership without naming what each side is measured on.
+- Announce before the joint work has a named owner on both sides.
+- Let a partnership run past its review date on goodwill.
+- Grant exclusivity without a performance floor that ends it.

--- a/plugins/customer-experience/skills/escalation-management/SKILL.md
+++ b/plugins/customer-experience/skills/escalation-management/SKILL.md
@@ -57,3 +57,10 @@ correctly, did we communicate on time, and what would have prevented it.
 
 Escalation volume is a health metric for the whole function. Rising escalations mean the normal path
 is failing more often, and that is the thing to fix.
+
+## Never
+
+- Escalate without naming an owner. An escalation with no name on it is a broadcast.
+- Commit to a fix date on the customer's call before engineering has said one exists.
+- Let the executive sponsor become the case owner. Sponsors unblock; they do not run the case.
+- Close on the technical fix. It closes when the customer says it is closed.

--- a/plugins/customer-experience/skills/self-service-and-knowledge/SKILL.md
+++ b/plugins/customer-experience/skills/self-service-and-knowledge/SKILL.md
@@ -62,3 +62,10 @@ volume for a topic falls after content ships.
 
 Watch articles with high views *and* a high subsequent contact rate. Those are articles that are
 failing to answer, and they look like your best-performing content.
+
+## Never
+
+- Write an article for a problem the product should not have. Fix the product and delete the article.
+- Publish without an owner and a review date. Stale help is worse than no help.
+- Measure a knowledge base by article count.
+- Hide the path to a human. Deflection that traps people costs more than the ticket would have.

--- a/plugins/customer-experience/skills/support-operations/SKILL.md
+++ b/plugins/customer-experience/skills/support-operations/SKILL.md
@@ -68,3 +68,10 @@ by a wide margin and then blames the team.
 
 Review a sample of resolved contacts against a rubric agreed with the team, and coach against it.
 Reviewing only escalations trains for defense rather than quality.
+
+## Never
+
+- Staff to average volume. Support arrives in peaks.
+- Publish a service level you have not staffed to meet.
+- Manage on handle time. It optimizes for closing tickets, not for solving problems.
+- Let a repeat driver stay a support problem. Route it to whoever owns the cause.

--- a/plugins/data-analytics/skills/business-intelligence/SKILL.md
+++ b/plugins/data-analytics/skills/business-intelligence/SKILL.md
@@ -63,3 +63,10 @@ check every figure by hand.
 
 Dashboards accumulate. Review usage periodically and retire what nobody opens — with a notice period,
 since the one person using it may be using it for something important.
+
+## Never
+
+- Build a dashboard nobody has a decision for. Start from the decision.
+- Ship a metric with two definitions live at the same time.
+- Leave a dashboard published with no owner. Unowned dashboards get trusted, then get wrong.
+- Show a number without the denominator and the window it covers.

--- a/plugins/demand-generation/skills/ai-search-optimization/SKILL.md
+++ b/plugins/demand-generation/skills/ai-search-optimization/SKILL.md
@@ -44,3 +44,9 @@ correcting the source, not the assistant.
 Click-through will fall on informational queries even as influence rises. Track citation and mention
 frequency, and downstream branded search and direct traffic, rather than judging this program on
 organic sessions — that metric will say you are losing while you are winning.
+
+## Never
+
+- Optimize for one assistant's current behavior. Retrieval and citation rules change without notice and without a changelog.
+- Assume being crawlable means being citable. Models cite sources that answer a question cleanly, not sources that merely exist.
+- Leave an inaccurate representation uncorrected because it is not on your site. The claim propagates whether or not you own the page it came from.

--- a/plugins/demand-generation/skills/app-store-optimization/SKILL.md
+++ b/plugins/demand-generation/skills/app-store-optimization/SKILL.md
@@ -46,3 +46,10 @@ Watch review text for recurring themes — it is the cheapest continuous product
 
 Change one element at a time and let it run a full weekly cycle; app traffic is strongly
 day-of-week seasonal. Attributing a lift to the wrong change is worse than not testing.
+
+## Never
+
+- Chase a keyword the app does not deliver on. Installs from a mismatched query become one-star reviews and a worse ranking than you started with.
+- Change metadata, screenshots, and the icon in the same release. Nothing that moves afterward can be attributed.
+- Solicit ratings from a user mid-task. The prompt lands where frustration is highest and the score reflects that.
+- Ignore reviews on the version you just shipped. They are the fastest signal you will get that a release broke something.

--- a/plugins/demand-generation/skills/experimentation/SKILL.md
+++ b/plugins/demand-generation/skills/experimentation/SKILL.md
@@ -46,3 +46,10 @@ tests a year — spend them on structural questions, not button colors.
 
 Keep a log of every test: hypothesis, result, decision. Without it, teams re-run the same tests every
 eighteen months and re-learn the same things.
+
+## Never
+
+- Stop a test because it reached significance early. Peeking until it looks conclusive manufactures the result.
+- Run a test that cannot reach adequate sample size in a reasonable window. Ship the change on judgment instead and say so.
+- Change more than one variable and attribute the outcome to the one you liked.
+- Count a flat result as a failure. A well-run test that rules out a plausible idea has bought information.

--- a/plugins/demand-generation/skills/landing-page-cro-expert/SKILL.md
+++ b/plugins/demand-generation/skills/landing-page-cro-expert/SKILL.md
@@ -70,6 +70,12 @@ objections handled, and visual hierarchy supporting the path.
 Publish the criteria with the score. A page scored 6/10 with no rubric produces an argument; the
 same score with the rubric produces a work list.
 
+## Never
+
+- Rewrite before diagnosing. Most pages that fail to convert are failing above the fold or off the page entirely, in the traffic.
+- Test a variant you cannot explain the hypothesis for. A win you cannot account for does not generalize.
+- Remove an objection from the page because it is uncomfortable. It does not leave the buyer's head, only your copy.
+
 ## Return contract
 
 Findings ordered by expected impact, each with the evidence, the specific fix, and effort. The one

--- a/plugins/demand-generation/skills/lead-capture/SKILL.md
+++ b/plugins/demand-generation/skills/lead-capture/SKILL.md
@@ -52,3 +52,10 @@ Popups work and are widely hated; both facts matter.
 Every field costs conversion. Ask for what you need to do the next step and nothing for a later one
 — enrichment can fill the rest. Explain any field whose purpose is not obvious, since unexplained
 fields are where people abandon.
+
+## Never
+
+- Gate something the buyer can get ungated elsewhere in one click.
+- Ask for a field nobody downstream uses. Every additional field costs conversion and the sales team is not reading it.
+- Trigger a popup before the visitor has seen anything worth staying for.
+- Treat a form fill as intent. Most of them are people who wanted the asset.

--- a/plugins/demand-generation/skills/listing-distribution/SKILL.md
+++ b/plugins/demand-generation/skills/listing-distribution/SKILL.md
@@ -52,3 +52,9 @@ set is worse than nothing.
 
 Set a periodic sweep: listings drift out of date, and an aggregator showing your old pricing will
 outrank your own page for some queries.
+
+## Never
+
+- List everywhere available. Directories with no traffic cost maintenance and dilute nothing but your attention.
+- Let listing copy drift from the positioning of record. Every stale listing is a competing description of the product.
+- Solicit reviews only after a customer complains, or only from customers you know are happy. Both distort the signal you are buying.

--- a/plugins/demand-generation/skills/marketing-analytics/SKILL.md
+++ b/plugins/demand-generation/skills/marketing-analytics/SKILL.md
@@ -51,3 +51,10 @@ nobody.
 Show the metric, its comparison period, and the decision it informs. A number with no comparison is
 not information. Where a number moved, the report should say why or say that the cause is unknown —
 "unknown" is a legitimate and useful finding.
+
+## Never
+
+- Add tracking before the plan names the events and their properties. Retrofitting a schema onto live data is a migration, not an edit.
+- Report an attribution number without saying which model produced it. The same period looks like different businesses under first and last touch.
+- Change an event definition without versioning it. Every historical comparison silently becomes wrong.
+- Build a dashboard nobody named a decision for.

--- a/plugins/demand-generation/skills/seo-strategy/SKILL.md
+++ b/plugins/demand-generation/skills/seo-strategy/SKILL.md
@@ -83,6 +83,12 @@ Rank fixes by traffic at risk against effort. In practice the order is almost al
 problems, then intent mismatch on high-value pages, then internal linking, then structured data,
 then everything else.
 
+## Never
+
+- Chase rankings for a term the page cannot satisfy. The click arrives, bounces, and teaches the engine the page was wrong.
+- Restructure a site without a redirect map. Lost link equity does not come back on its own.
+- Judge a change in the first fortnight. Search feedback is slow enough that early movement is usually noise.
+
 ## Return contract
 
 Findings by severity with the evidence for each, the sequenced fix list, expected impact and when it

--- a/plugins/executive/skills/agent-hierarchy/SKILL.md
+++ b/plugins/executive/skills/agent-hierarchy/SKILL.md
@@ -61,6 +61,13 @@ decision is raised, assign it the next number immediately — before it is answe
 lettered options with an explicit recommendation. Never renumber, never reuse a number, and record
 resolutions in place rather than deleting them.
 
+## Never
+
+- Add an agent before the surface it will own exists. The map comes first, the agent second.
+- Let two agents hold a write claim on the same path. Overlap resolves itself as a race.
+- Hand-edit a generated artifact instead of the source it derives from.
+- Skip the guard because the change is small. Small changes are how surfaces drift.
+
 ## References
 
 - `references/playbook.md` — the full 415-line playbook: surface splitting, the guard, the

--- a/plugins/executive/skills/business-growth-consultant/SKILL.md
+++ b/plugins/executive/skills/business-growth-consultant/SKILL.md
@@ -68,6 +68,13 @@ Watch for metrics that improve while the business worsens: revenue up with margi
 with activation down, traffic up with conversion down. Each means the mix shifted, and the headline
 number is hiding it.
 
+## Never
+
+- Recommend tactics before naming the constraint. Effort applied away from the constraint does nothing.
+- Stack initiatives until none of them gets the attention it needs to work.
+- Present a plan with no way to tell within a quarter whether it is working.
+- Recommend more spend into a funnel that does not convert what it already receives.
+
 ## Return contract
 
 1. **The constraint**, named, with the evidence.

--- a/plugins/executive/skills/ceo-advisor/SKILL.md
+++ b/plugins/executive/skills/ceo-advisor/SKILL.md
@@ -65,6 +65,13 @@ Where a commitment was missed repeatedly, the interesting question is not why th
 whether the commitment was ever realistic, or whether it is not actually a priority — either answer
 is useful, and both are better than a fourth attempt.
 
+## Never
+
+- Soften an assessment because it is unwelcome. That is the one thing this role exists for.
+- Give advice without saying what would change your mind.
+- Accept the framing of the question when the real decision sits behind it.
+- Lay out options and stop. Say which one you would pick.
+
 ## Return contract
 
 1. **The real decision**, restated.

--- a/plugins/it-operations/skills/virtualization-operations/SKILL.md
+++ b/plugins/it-operations/skills/virtualization-operations/SKILL.md
@@ -80,3 +80,10 @@ for.
 Hybrid is the normal end state, not a transitional embarrassment. What makes it painful is running
 two operating models with two sets of habits, so decide deliberately which one owns identity,
 monitoring, and backup rather than letting each side answer differently.
+
+## Never
+
+- Provision a guest without an owner, a lifetime, and a decommission trigger.
+- Size a cluster with no headroom to lose a node during maintenance.
+- Grow a guest's resources before checking whether the guest itself is misbehaving. Oversizing hides the bug and eats the consolidation ratio.
+- Move a workload to cloud to escape a capacity problem you have not diagnosed on-premises.

--- a/plugins/legal-risk/skills/corporate-governance/SKILL.md
+++ b/plugins/legal-risk/skills/corporate-governance/SKILL.md
@@ -63,3 +63,10 @@ destroy anything under a legal hold, and know who can place one.
 Some responsibilities sit between functions and get dropped. When one appears, do not debate the
 right home in the abstract — assign it to whoever bears the consequence if it fails, and record the
 assignment. An owner who is imperfect beats an owner who is undecided.
+
+## Never
+
+- Take an action that requires board or member approval and paper it afterward.
+- Let the corporate record live in someone's inbox.
+- Sign outside a documented delegation of authority because the deal is urgent.
+- Destroy records on schedule while a legal hold is in place. A hold suspends the schedule.

--- a/plugins/legal-risk/skills/enterprise-risk/SKILL.md
+++ b/plugins/legal-risk/skills/enterprise-risk/SKILL.md
@@ -53,3 +53,10 @@ found then cannot be fixed retroactively.
 Leadership needs the few risks whose residual exposure is above appetite, what is being done, and
 what needs a decision. Not the whole register. A risk report that requires reading forty rows to
 find the three that matter will not be read.
+
+## Never
+
+- Score residual risk on controls that are planned rather than operating.
+- Accept a risk without naming who accepted it and when it is reviewed again.
+- Keep a register with no review cadence. That is documentation, not risk management.
+- Close a risk because the project that raised it ended.

--- a/plugins/legal-risk/skills/privacy-and-data-protection/SKILL.md
+++ b/plugins/legal-risk/skills/privacy-and-data-protection/SKILL.md
@@ -55,3 +55,10 @@ data is located across systems, and the deadline. Locating the data is the part 
 
 For breaches, know your notification clock before you need it — several regimes measure it in hours
 from awareness. Decide in advance who determines that awareness has occurred.
+
+## Never
+
+- Collect data because it may be useful later. Purpose first, then collection.
+- Retain personal data past the period you published.
+- Send personal data to a vendor before the contract terms and the transfer basis are in place.
+- Load production personal data into a test environment.

--- a/plugins/marketing/skills/behavioral-marketing/SKILL.md
+++ b/plugins/marketing/skills/behavioral-marketing/SKILL.md
@@ -69,3 +69,9 @@ buy anyway.
 - **Effects are contextual and interact.** Published effect sizes are directional, not predictions.
   Treat every application as a hypothesis to test rather than a known quantity — this is where
   behavioral marketing most often overreaches.
+
+## Never
+
+- Deploy an effect without being able to name the mechanism. A tactic borrowed without its mechanism fails silently in a context that differs in ways nobody checked.
+- Manufacture scarcity, urgency, or social proof that is not true. It works once and costs the relationship permanently.
+- Treat a published effect size as a guaranteed lift. Those numbers come from populations and contexts that are not yours.

--- a/plugins/marketing/skills/brand-voice/SKILL.md
+++ b/plugins/marketing/skills/brand-voice/SKILL.md
@@ -46,3 +46,9 @@ Include a **do-not** list. Voice guides fail on what they permit, not what they 
 Draft two paragraphs and read them to the person cold. If they say "close, but I wouldn't say it
 that way," ask exactly what they would say — that correction is the most valuable data in the
 process.
+
+## Never
+
+- Build a voice guide from copy the person did not write. Agency and ghostwritten material describes someone else's voice.
+- Describe voice in adjectives alone. "Friendly but authoritative" is unusable without paired examples of what passes and what fails.
+- Apply a voice guide to a format it was never sampled from. How someone writes an email is not how they write a keynote.

--- a/plugins/marketing/skills/chief-content-officer/SKILL.md
+++ b/plugins/marketing/skills/chief-content-officer/SKILL.md
@@ -80,3 +80,10 @@ piles: **update** (performing, stale), **consolidate** (several thin pieces on o
 (no traffic, no links, no strategic value).
 
 Most libraries have more value in the promote pile than in anything unwritten.
+
+## Never
+
+- Start production before the brief names the argument. An idea is a title; a piece needs a claim.
+- Fill the calendar to capacity. A pipeline with no slack cannot absorb the one piece worth dropping everything for.
+- Choose the format before the argument. That is how a topic that wanted six hundred words becomes a video series.
+- Retire a piece that has inbound links without redirecting it.

--- a/plugins/marketing/skills/content-strategy/SKILL.md
+++ b/plugins/marketing/skills/content-strategy/SKILL.md
@@ -48,6 +48,12 @@ everything on traffic is why content programs drift toward the reach end and sta
 Set a review point where a topic that is not working gets dropped. Content strategies fail by
 accumulation.
 
+## Never
+
+- Claim a territory you cannot sustain publishing on. Withdrawing from one costs more than never entering it.
+- Commit to a platform without deciding who runs it every week.
+- Judge a content program on traffic when the objective was demand.
+
 ## Return contract
 
 Territory, audience, the four-way format budget, cadence, platforms with rationale, first ten pieces

--- a/plugins/marketing/skills/marketing-campaign-planner/SKILL.md
+++ b/plugins/marketing/skills/marketing-campaign-planner/SKILL.md
@@ -80,6 +80,13 @@ contact with a considered buyer.
 - What happens if it works far better than expected — can delivery, support, and inventory absorb
   it?
 
+## Never
+
+- Run a campaign carrying more than one story. A second message halves the first.
+- Add a channel because it is available. Every channel added is one somebody has to run properly.
+- Set a launch date before the assets that gate it have named owners.
+- Commit to an objective you cannot measure with a number you already collect.
+
 ## Return contract
 
 The story in one sentence, objective and leading indicator, channels with sequencing rationale,

--- a/plugins/marketing/skills/marketing-copywriting/SKILL.md
+++ b/plugins/marketing/skills/marketing-copywriting/SKILL.md
@@ -49,3 +49,9 @@ Edit in passes; doing them at once does none of them.
 Empty openers ("In today's fast-paced world"), we-focused framing where you-focused works, hedges
 that weaken a true claim, feature lists with no consequence attached, and any adjective a competitor
 could equally use.
+
+## Never
+
+- Write before you know what the reader should do next.
+- Edit for elegance before the argument is right. Polished copy for the wrong claim is the more expensive mistake.
+- Approve copy nobody read aloud. Rhythm problems are inaudible on the page.

--- a/plugins/marketing/skills/newsletter-writer/SKILL.md
+++ b/plugins/marketing/skills/newsletter-writer/SKILL.md
@@ -81,3 +81,9 @@ read-aloud pass catches what silent reading never does.
 
 One issue contains several short-form posts, a talk track, and often a longer piece. Plan which
 before writing, so the sections that should stand alone are written to.
+
+## Never
+
+- Write a subject line the opening does not pay off. It buys one open and costs the next.
+- Sell in an issue that gave nothing else. The trust spent is not recovered by the next good one.
+- Send an offer to the whole list when it applies to part of it.

--- a/plugins/marketing/skills/public-relations/SKILL.md
+++ b/plugins/marketing/skills/public-relations/SKILL.md
@@ -46,3 +46,10 @@ explicitly agreed in advance — and even then, assume it may not hold.
   guarantee a second story.
 - Correct genuine errors privately, with evidence, and specifically. Vague complaints about tone
   achieve nothing.
+
+## Never
+
+- Pitch a story that is only news to you. A funding round, a hire, and a redesign are not news outside the company.
+- Send a pitch to a journalist whose recent work you have not read.
+- Enter an interview without deciding in advance what you will not say.
+- Respond to a damaging story before establishing whether it is accurate.

--- a/plugins/marketing/skills/social-post-craft/SKILL.md
+++ b/plugins/marketing/skills/social-post-craft/SKILL.md
@@ -51,3 +51,9 @@ most platforms strip formatting.
 - Would you send this to one person you respect? If not, do not send it to everyone.
 
 A draft that fails these gets rewritten, not published with a caveat.
+
+## Never
+
+- Publish a post whose first line only works after the reader expands it.
+- Reuse one format across platforms unchanged. Line breaks and truncation differ, and the post breaks in ways the composer does not show you.
+- Post a link without deciding whether the platform suppresses them.

--- a/plugins/marketing/skills/video-content/SKILL.md
+++ b/plugins/marketing/skills/video-content/SKILL.md
@@ -49,3 +49,9 @@ uniformly intense video is as tiring as a flat one.
 Plan derivatives before filming, not after. Segments intended to stand alone get shot to stand
 alone. Extracting short-form from a video not built for it produces clips that need context they do
 not have.
+
+## Never
+
+- Produce before the title and thumbnail exist. Packaging decides whether anything you shot gets seen.
+- Open with a preamble. The first seconds are where an audience is lost, not where it is warmed up.
+- Diagnose a video on view count alone. Impressions, click-through, and retention fail differently and need different fixes.

--- a/plugins/marketing/skills/visual-content/SKILL.md
+++ b/plugins/marketing/skills/visual-content/SKILL.md
@@ -50,3 +50,9 @@ Write the prompt as a brief: subject, composition, lighting, palette, mood, and 
 constraints. Generate one concept per image. Then check the output actually renders any embedded
 text correctly and matches the brand palette — generated imagery drifts, and drifted brand color is
 worse than no brand color.
+
+## Never
+
+- Choose a visual format before knowing whether the content is a sequence, a comparison, or a single claim.
+- Design at full size for something that will be seen at thumbnail size.
+- Put load-bearing information in an image alone. It is unsearchable, untranslatable, and invisible to a screen reader.

--- a/plugins/marketing/skills/youtube-producer/SKILL.md
+++ b/plugins/marketing/skills/youtube-producer/SKILL.md
@@ -87,3 +87,10 @@ different kinds of value teaches the audience nothing about whether to click the
 
 Plan repurposing before filming — segments meant to stand alone as short-form get shot to stand
 alone.
+
+## Never
+
+- Produce an idea whose title you cannot write. If the title is hard, the idea is not yet clear.
+- Judge a video on its first day. The signal that matters accrues over weeks.
+- Change what the channel is about because one video underperformed.
+- Fix retention by cutting faster when the problem is that the promise was wrong.

--- a/plugins/operations/skills/process-design/SKILL.md
+++ b/plugins/operations/skills/process-design/SKILL.md
@@ -51,6 +51,13 @@ system: required fields, blocking gates, defaults that are correct, automated ha
 **Never fix a recurring failure with a reminder.** If people are forgetting a step, the system
 permits forgetting it. Fix that.
 
+## Never
+
+- Redesign from the documented process. Map what people actually do first.
+- Optimize a step that is not the constraint. Everything you speed up ahead of it just queues.
+- Add an approval to prevent a failure that happened once.
+- Hand over a process with no owner and no measure. It reverts within a quarter.
+
 ## Return contract
 
 Current state with elapsed and touch time, the constraint and its evidence, the redesign, what it

--- a/plugins/operations/skills/vendor-management/SKILL.md
+++ b/plugins/operations/skills/vendor-management/SKILL.md
@@ -50,3 +50,10 @@ triples its price. For each, know the exit path and roughly what it costs — an
 never been thought through is not an option, it is a hope.
 
 Maintain your own copy of your data continuously where the vendor holds anything critical.
+
+## Never
+
+- Sign before you know what leaving costs — data export, notice period, transition support.
+- Let the vendor write the requirements you evaluate them against.
+- Reach a renewal date without having started the renewal. The auto-renew clause is their leverage.
+- Concentrate a critical dependency on one vendor without saying so out loud and pricing the risk.

--- a/plugins/product/skills/brand-identity/SKILL.md
+++ b/plugins/product/skills/brand-identity/SKILL.md
@@ -44,3 +44,10 @@ Collect real surfaces — product, marketing site, email, social, sales collater
 for: palette drift, more type families than the system defines, logo variants nobody sanctioned, and
 tone that changes between surfaces. Report by severity, and separate what breaks the system from
 what merely was not specified.
+
+## Never
+
+- Pick color and type before you know what the brand has to sound like and what it will sit next to.
+- Ship a palette you have not checked for contrast at real sizes on real backgrounds.
+- Use color alone to carry state, meaning, or error.
+- Add a typeface because a page needs variety. Variety comes from weight, size, and spacing inside the system you already have.

--- a/plugins/product/skills/design-styles/SKILL.md
+++ b/plugins/product/skills/design-styles/SKILL.md
@@ -51,3 +51,10 @@ Fails when: applied to high-frequency tools, where the motion and padding become
 3. Apply completely. A utilitarian grid with soft shadows is not a hybrid.
 4. Do not change layout structure to suit the style. If structure must change, that is a separate
    decision, stated as one.
+
+## Never
+
+- Mix two styles on one surface because each has a part you like. Pick one and hold it.
+- Choose a style before you know the content it has to carry and who is reading it.
+- Treat a style as decoration applied at the end. It decides density, spacing, and hierarchy from the first screen.
+- Copy a reference into a layout your real content cannot fill. Empty space that was supposed to hold something reads as broken.

--- a/plugins/product/skills/design-system/SKILL.md
+++ b/plugins/product/skills/design-system/SKILL.md
@@ -41,6 +41,13 @@ a polish item; it is whether people can use it.
 - Never remove a token or component because it looks unused. You cannot see every consumer from
   inside the system. Deprecate, announce, then remove.
 
+## Never
+
+- Add a component for a single screen. A one-use component is a snippet, not a system.
+- Hard-code a value a token already covers. The exception becomes the next inconsistency.
+- Redefine what an existing token means instead of adding one. Changing a semantic silently redecorates everything downstream.
+- Ship a component without its states documented — empty, loading, error, disabled.
+
 ## Return contract
 
 Report tokens added or changed, components affected, anything now inconsistent with the system, and

--- a/plugins/product/skills/interface-redesign/SKILL.md
+++ b/plugins/product/skills/interface-redesign/SKILL.md
@@ -47,6 +47,13 @@ Fix in this order, because each makes the next easier to see:
 Rebuild only when the structure is wrong — when the information architecture does not match how
 people work. Everything else is a restyle, and a restyle that ships beats a rebuild that stalls.
 
+## Never
+
+- Restyle a screen whose problem is structural. New paint on a broken flow buys nothing.
+- Change navigation and visual language in the same release. When something breaks you will not know which one did it.
+- Remove a path because it looks unused without checking who uses it and what they do next.
+- Ship a redesign with no way back. Keep the old path reachable until the new one is proven.
+
 ## Return contract
 
 Findings by category with severity, the sequenced plan, what you would do first if only one day were

--- a/plugins/product/skills/ux-product-auditor/SKILL.md
+++ b/plugins/product/skills/ux-product-auditor/SKILL.md
@@ -86,3 +86,10 @@ Where the right fix is uncertain, propose the cheapest way to find out rather th
 Rank by users affected × severity ÷ effort. Then state the one thing to fix first, and be willing to
 say that most of the list is not worth doing yet. A prioritized audit is more useful than a complete
 one.
+
+## Never
+
+- Report a finding without the path that produces it. A claim nobody can reproduce gets ignored.
+- Rank findings by how easy they are to fix. Rank by cost to the user, then note which ones are cheap.
+- Audit a staging build or a marketing page that real users never touch.
+- Call a preference a defect. Say what breaks and for whom, or leave it out.

--- a/plugins/product/skills/visual-reference-generation/SKILL.md
+++ b/plugins/product/skills/visual-reference-generation/SKILL.md
@@ -41,3 +41,10 @@ not the screenshot.
 
 Say explicitly what in the reference is **direction** and what is **placeholder**. A developer
 handed a concept will otherwise implement the lorem ipsum faithfully.
+
+## Never
+
+- Generate before the content, states, and constraints are settled. A reference built on placeholder copy hides every real problem.
+- Present a generated image as a working design. Say what it is.
+- Generate with filler text where real string lengths decide the layout.
+- Hand off an image as the spec. Hand off the tokens, spacing, and states behind it.

--- a/plugins/revenue/skills/activation/SKILL.md
+++ b/plugins/revenue/skills/activation/SKILL.md
@@ -56,3 +56,10 @@ for.
 
 Percentage reaching the activation moment, and time to reach it. Signup conversion alone will
 happily improve while activation falls.
+
+## Never
+
+- Pick an activation moment because it is easy to measure. It has to be the point where the user gets the value they came for.
+- Add a step to onboarding without removing one. Every screen between signup and value costs you users.
+- Ask at signup for anything you do not need to deliver the first result. Collect the rest later, in context.
+- Count signups as activation. A user who never reached the value moment did not activate.

--- a/plugins/revenue/skills/outbound-prospecting/SKILL.md
+++ b/plugins/revenue/skills/outbound-prospecting/SKILL.md
@@ -55,3 +55,10 @@ Use a subdomain for outbound so a reputation problem cannot take down your trans
   statement.
 - **Replies, no meetings** — a qualification problem: you are reaching people who cannot act.
 - **Meetings, no pipeline** — the segment is wrong.
+
+## Never
+
+- Send before the list is qualified. A good message to the wrong person is still a bad message.
+- Send outbound from the domain that carries your customer and billing mail. Prospecting burns sender reputation; keep it on a separate domain.
+- Keep sequencing someone who replied. Pull them out the moment a human is in the thread.
+- Judge a sequence on open rates. Opens are unreliable and unactionable; judge on replies and meetings held.

--- a/plugins/revenue/skills/pricing-and-packaging/SKILL.md
+++ b/plugins/revenue/skills/pricing-and-packaging/SKILL.md
@@ -52,3 +52,10 @@ buy one conversion and lose the account.
 - Announce with real notice and a clear reason.
 - Change one thing at a time — price and packaging together makes the result unreadable.
 - Model the downside first: at what churn rate does this increase lose money?
+
+## Never
+
+- Change price without telling existing customers before it takes effect and honoring what they already signed.
+- Pick a pricing metric the customer cannot predict. If they cannot forecast the bill, they will not sign.
+- Add a tier to close a single deal. Tiers are a permanent tax on every conversation after it.
+- Discount without taking something back in exchange — term, scope, payment timing, a reference. A free discount resets the price for everyone.

--- a/plugins/revenue/skills/referral-programs/SKILL.md
+++ b/plugins/revenue/skills/referral-programs/SKILL.md
@@ -53,3 +53,10 @@ you already had.
 
 Track referred-customer retention against baseline. If referred customers retain worse, the
 incentive is buying the wrong behavior and the program is losing money while appearing to work.
+
+## Never
+
+- Launch referrals before the product retains. A referral program amplifies whatever is already there, churn included.
+- Pay a reward before the referred account is real — activated, paid, and past the refund window.
+- Ask for a referral in the same breath as an apology or an open support escalation.
+- Run affiliates and customer referrals on the same terms. They attract different people and need different controls.

--- a/plugins/revenue/skills/revenue-operations/SKILL.md
+++ b/plugins/revenue/skills/revenue-operations/SKILL.md
@@ -71,6 +71,13 @@ be unusable within two quarters.
 Never require a field whose value is not used in a decision. Every unnecessary field trains sellers
 to enter garbage in all of them.
 
+## Never
+
+- Change a definition without restating history on the new one. A metric that moved because you redefined it is not a result.
+- Report a forecast number you cannot trace back to named deals.
+- Let two systems each keep their own version of the same field. Pick the source of truth and make the other read from it.
+- Score leads with a model you cannot explain to the reps who have to work them.
+
 ## Return contract
 
 State the definitional gaps found, the process change proposed, what it costs sellers in time, and

--- a/plugins/revenue/skills/sales-enablement/SKILL.md
+++ b/plugins/revenue/skills/sales-enablement/SKILL.md
@@ -48,3 +48,10 @@ moment inside five minutes when time gets cut.
 Collateral rots. Every asset needs an owner and a review date, and anything referencing pricing,
 competitors, or product capability needs checking every quarter. A battlecard describing a
 competitor's old product loses deals.
+
+## Never
+
+- Build collateral before you know where deals actually stall. Ask the reps and read the losses first.
+- Ship a deck or one-pager with no owner and no review date. Unmaintained collateral is worse than none.
+- Order a demo around the product's feature list instead of the order the buyer's problem unfolds in.
+- Count enablement as done at delivery. It is done when reps use it in live deals.

--- a/plugins/security/skills/access-and-identity/SKILL.md
+++ b/plugins/security/skills/access-and-identity/SKILL.md
@@ -64,3 +64,10 @@ unnecessary or belongs to someone who left.
 Look for: permissions granted to individuals rather than roles, roles nobody can define, standing
 administrative access, accounts whose owner has left, service credentials with no owner, and systems
 outside SSO. Each is a specific fix, and the list is nearly always the same list.
+
+## Never
+
+- Grant standing access where time-bound access would do the same job.
+- Leave an account active while an offboarding ticket works its way through. Cut access first, reconcile after.
+- Share a credential between people. If two people can use it, no log tells you which one did.
+- Approve your own access request, or review a group you belong to.

--- a/plugins/security/skills/incident-response/SKILL.md
+++ b/plugins/security/skills/incident-response/SKILL.md
@@ -65,3 +65,10 @@ same incident recurs.
 The plan matters less than having run it. Exercise once a year at minimum: a tabletop against a
 realistic scenario finds the gaps — who has authority out of hours, where the credentials are, who
 calls counsel — at a time when finding them is free.
+
+## Never
+
+- Rebuild or wipe a compromised host before evidence is captured.
+- Let the person running the technical response also own external communication.
+- Close an incident before you can say how entry happened and that the path is shut.
+- Speculate about cause or attribution outside the response channel while the incident is open.

--- a/plugins/security/skills/security-architecture-review/SKILL.md
+++ b/plugins/security/skills/security-architecture-review/SKILL.md
@@ -61,6 +61,13 @@ What data leaves, under what agreement, with what access, and what happens if th
 Scope credentials to the minimum, prefer short-lived tokens, and know how to revoke without an
 outage.
 
+## Never
+
+- Approve a design on the promise of a control with no named owner and no date.
+- Accept "it is internal" as an authorization boundary.
+- Review the diagram instead of the change. Read what is actually being built.
+- Sign off on a third-party integration without knowing what data leaves and under what terms.
+
 ## Return contract
 
 Findings by severity, each with: the concrete attack, what the attacker gains, whether it blocks

--- a/plugins/security/skills/vulnerability-management/SKILL.md
+++ b/plugins/security/skills/vulnerability-management/SKILL.md
@@ -66,3 +66,10 @@ good-faith reporter as an adversary is how a private report becomes a public one
 
 Leadership needs: what is exposed and unfixed past SLA, the trend, and what needs a decision. Not
 the count of findings, which mostly measures how much you scanned.
+
+## Never
+
+- Rank on CVSS alone. A score is not exploitability in your environment.
+- Accept a risk without a named accepting owner and a date it gets revisited.
+- Push a patch to production without knowing what it changes and how to roll it back.
+- Report a shrinking backlog that shrank by reclassification rather than by remediation.

--- a/plugins/technology/skills/ai-workflow-architect/SKILL.md
+++ b/plugins/technology/skills/ai-workflow-architect/SKILL.md
@@ -86,3 +86,10 @@ harder ones, and the first automation teaches you what the second should look li
 Data leaving your control, model output reaching customers unreviewed, a silent dependency on a
 vendor's pricing, and the maintenance burden landing on one person. Name the owner of each before
 building, not after.
+
+## Never
+
+- Automate a process nobody has written down. You will automate the exceptions along with the work.
+- Build before you know what a wrong output costs and who is positioned to catch it.
+- Put a model where a rule would do. Deterministic steps should stay deterministic.
+- Ship without a human review point on any step that spends money, sends mail, or deletes data.

--- a/plugins/technology/skills/prompt-optimizer/SKILL.md
+++ b/plugins/technology/skills/prompt-optimizer/SKILL.md
@@ -86,3 +86,10 @@ Do not assume a prompt transfers. Models differ in how they weight system versus
 how they handle long context, and how they respond to formatting. Re-test on the target model, and
 be especially suspicious of prompts tuned through many small iterations — those are often fitted to
 one model's quirks.
+
+## Never
+
+- Rewrite a prompt before reading the failing outputs. You will fix the wrong thing.
+- Change more than one thing between test runs.
+- Judge a change on a single output. Sampling variance will fool you.
+- Keep an instruction because it was already there. Every line has to earn its tokens.

--- a/plugins/technology/skills/skill-authoring/SKILL.md
+++ b/plugins/technology/skills/skill-authoring/SKILL.md
@@ -47,3 +47,10 @@ family into one skill with references, over adding a near-neighbor.
 
 Write three requests that should trigger it and two that should not, and check the description
 actually discriminates. If a near-miss request would pull it in, tighten the description.
+
+## Never
+
+- Ship a skill whose description does not say when to use it. A skill that never triggers is dead weight.
+- Write a skill that restates what the model already does well without prompting.
+- Let two skills claim the same trigger. Move the boundary or merge them.
+- Ship without running the skill against the case that motivated writing it.

--- a/plugins/technology/skills/systematic-debugging/SKILL.md
+++ b/plugins/technology/skills/systematic-debugging/SKILL.md
@@ -34,6 +34,13 @@ explanation has not fixed anything — it has moved the failure somewhere you ar
   knowing what threw it.
 - **Trusting the error message's location.** Where it surfaced is rarely where it originated.
 
+## Never
+
+- Close a bug without a reproduction that failed before the fix and passes after it.
+- Deploy a change to production to find out whether it works. Reproduce somewhere you can observe first.
+- Change the environment and the code in the same step.
+- Leave a debugging aid in the code as the fix — a widened timeout, a disabled check, a swallowed exception.
+
 ## Return contract
 
 State the reproduction, the proven cause, the fix, and the verification that the fix addresses that

--- a/plugins/technology/skills/test-driven-development/SKILL.md
+++ b/plugins/technology/skills/test-driven-development/SKILL.md
@@ -40,6 +40,13 @@ claim.
 - Never mock what you own — mock the network and the clock, not your own modules. Mocking your own
   code tests the mock.
 
+## Never
+
+- Write the test after the code and call it test-driven. You will test what you built rather than what was required.
+- Skip watching the test fail. A test that has never failed proves nothing.
+- Delete or skip a failing test to unblock a release. Fix it, or revert what broke it.
+- Treat a coverage number as the goal. It counts lines executed, not behavior pinned down.
+
 ## Return contract
 
 Report the tests added, what each pins down, what is deliberately untested and why, and the actual


### PR DESCRIPTION
Two passes that both do the same job: make a skill useful to someone who is not a subject matter expert in it.

## 1. Never coverage — 90 → 146 of 146

Every skill now carries a `## Never` block. A skill that only says what to do leaves the failure modes implied; the Never block states them — the specific thing that goes wrong, and where it isn't obvious, one sentence on why. That is the part that stops a plausible-sounding wrong answer.

House style is bare imperative, three to four bullets, an optional consequence sentence. Sampled from the blocks already in the library rather than invented.

Several skills already had a section naming failures — the anti-patterns in `systematic-debugging`, the rules in `test-driven-development`, "what does not help" in `prompt-optimizer`, the rules in `agent-hierarchy`, the "Kill on sight" list in `marketing-copywriting`. In each case the new block names process failures those sections don't cover, so the two don't restate each other.

## 2. Named software tools — 28 skills

"CRM familiarity" tells a non-expert nothing. "Salesforce, HubSpot, Pipedrive, Zoho CRM, and similar" tells them what to look for and what they're looking at.

Every list closes with **and similar**, so it reads as illustrative rather than as a recommendation or an attempted survey. A rough **scale tier** is named only where scale actually changes the answer — the finance ledger, planning tools, revenue recognition subledgers, portfolio management, access review tooling. Everywhere else the options sit at the same tier and a tier would be noise.

Categories covered: accounting ledgers and close management, FP&A planning, revenue recognition, treasury and AP, GRC and compliance automation, contract lifecycle management, vulnerability scanning, identity and privileged access, support ticketing, ITSM, endpoint management, HRIS, backup including the SaaS retention gap, cloud platforms and infrastructure as code, CRM and sales engagement, marketing analytics and lifecycle automation, BI and semantic layers, warehouses and ingestion, delivery tracking, observability and on-call, design systems, and procure-to-pay.

`security-architecture-review` already had a `## Tooling` section written by category, so the product names went into it rather than beside it.

Each section closes on the judgment the tool cannot supply — an untested restore is not a backup; the CRM is the record and anything disagreeing with it is a report, not a number; the design system is the code, not the design file.

## Placement

`## Tooling` goes before `## Never`, which goes before `## Return contract` where one exists (and before `## References` in `agent-hierarchy`), so the closing contract stays last in the file.

## Verification

`scripts/check-all.sh` — all nine checks pass: surface map coherence, frontmatter validation across 146 skills, provenance, the three generated-artifact `--check` modes, skill reference resolution, US English spelling, and manifest parsing.

## Maintenance note

Named products date faster than the guidance around them. The "and similar" close and the by-category framing are meant to keep a stale name from reading as a stale recommendation, but this is the part of the library that will need periodic revisiting.