### PR TITLE
Name software tools by category across 28 skills

### DIFF
--- a/plugins/customer-experience/skills/support-operations/SKILL.md
+++ b/plugins/customer-experience/skills/support-operations/SKILL.md
@@ -69,6 +69,16 @@ by a wide margin and then blames the team.
 Review a sample of resolved contacts against a rubric agreed with the team, and coach against it.
 Reviewing only escalations trains for defense rather than quality.
 
+## Tooling
+
+Ticketing: Zendesk, Freshdesk, Intercom, Front, Help Scout, and similar; Jira Service
+Management where support and engineering work one queue.
+
+Knowledge base: usually the ticketing tool's own, or Confluence, Notion, or Guru.
+
+Quality review and workforce management — Klaus, Assembled, and similar — start paying off
+once you staff shifts rather than a team. Before that they are overhead.
+
 ## Never
 
 - Staff to average volume. Support arrives in peaks.

--- a/plugins/data-analytics/skills/business-intelligence/SKILL.md
+++ b/plugins/data-analytics/skills/business-intelligence/SKILL.md
@@ -64,6 +64,16 @@ check every figure by hand.
 Dashboards accumulate. Review usage periodically and retire what nobody opens — with a notice period,
 since the one person using it may be using it for something important.
 
+## Tooling
+
+BI: Power BI, Looker, Tableau, Metabase, Omni, Hex, and similar.
+
+Metric definitions belong in a semantic layer — dbt's, Looker's LookML, Cube — rather than
+in each dashboard's SQL, or the same metric will disagree with itself across two tabs.
+
+Spreadsheets remain the most-used BI tool in every organization. Plan for the export rather
+than pretending it will not happen.
+
 ## Never
 
 - Build a dashboard nobody has a decision for. Start from the decision.

--- a/plugins/data-analytics/skills/data-engineering/SKILL.md
+++ b/plugins/data-analytics/skills/data-engineering/SKILL.md
@@ -51,6 +51,17 @@ is valid but wrong. Assert on the data itself, in the pipeline, and fail loudly:
 A silent failure is worse than a loud one. Prefer stopping the pipeline to publishing data you do not
 trust.
 
+## Tooling
+
+Warehouses and lakehouses: Snowflake, BigQuery, Databricks, Redshift, and Postgres or
+DuckDB at small scale, and similar.
+
+Ingestion: Fivetran, Airbyte, Stitch, and similar. Transformation: dbt, SQLMesh.
+Orchestration: Airflow, Dagster, Prefect, and similar.
+
+Buy ingestion and build transformation. Connector maintenance returns nothing for the time
+your team puts into it.
+
 ## Never
 
 - Transform on ingest for business reasons and discard the raw copy.

--- a/plugins/demand-generation/skills/lifecycle-messaging/SKILL.md
+++ b/plugins/demand-generation/skills/lifecycle-messaging/SKILL.md
@@ -77,6 +77,17 @@ it, and never leave it to default to the first line of the body.
 - **Click but no conversion** — the destination, not the email.
 - **Rising unsubscribes** — frequency or relevance. Usually frequency.
 
+## Tooling
+
+Lifecycle automation: Customer.io, Braze, Iterable, Klaviyo for commerce, HubSpot or
+Marketo for B2B, and similar.
+
+Transactional sending is a separate job with separate reputation: Postmark, SendGrid,
+Resend, and similar. Keep it off the marketing domain.
+
+In-product messaging: Intercom, Appcues, Pendo, and similar. An email that should have been
+an in-app prompt reaches half the audience at best.
+
 ## Never
 
 - Send to a list that did not opt in.

--- a/plugins/demand-generation/skills/marketing-analytics/SKILL.md
+++ b/plugins/demand-generation/skills/marketing-analytics/SKILL.md
@@ -52,6 +52,18 @@ Show the metric, its comparison period, and the decision it informs. A number wi
 not information. Where a number moved, the report should say why or say that the cause is unknown —
 "unknown" is a legitimate and useful finding.
 
+## Tooling
+
+Product and web analytics: Google Analytics 4, Amplitude, Mixpanel, PostHog, Plausible,
+and similar.
+
+Attribution: HubSpot or Salesforce campaign reporting, Dreamdata, Rockerbox, and similar.
+All of them model rather than observe — treat the output as directional and say so when
+you present it.
+
+Warehouse-native reporting beats a vendor dashboard the moment you need to join spend to
+revenue on your own definitions.
+
 ## Never
 
 - Add tracking before the plan names the events and their properties. Retrofitting a schema onto live data is a migration, not an edit.

--- a/plugins/finance/skills/budgeting-and-forecasting/SKILL.md
+++ b/plugins/finance/skills/budgeting-and-forecasting/SKILL.md
@@ -44,6 +44,16 @@ recurring costs compound and are constantly under-reacted to.
 Explain the top few by value, not every line. A variance report covering everything gets read as
 nothing.
 
+## Tooling
+
+Planning: Anaplan, Pigment, Workday Adaptive Planning, Vena, Cube, and similar. A
+well-built spreadsheet on a clean chart of accounts beats a planning tool nobody has been
+staffed to maintain; move when budget owners outnumber the people who can hold the model
+in their head.
+
+Driver data comes from the ledger, the CRM, and the HRIS. The planning tool is only ever
+as current as those connections.
+
 ## Never
 
 - Present a forecast without saying what changed since the last one.

--- a/plugins/finance/skills/chief-financial-officer/SKILL.md
+++ b/plugins/finance/skills/chief-financial-officer/SKILL.md
@@ -91,6 +91,17 @@ These are the artifacts of record. Where two of them disagree, this one is right
 
 Escalate to Chief Executive when the plan is not fundable as written; to Legal & Risk on anything touching financial reporting obligations.
 
+## Tooling
+
+The stack a CFO is accountable for, by layer: the ledger (QuickBooks or Xero at small
+scale, NetSuite, Sage Intacct, or Dynamics 365 in the middle, SAP or Oracle at the top),
+planning (Anaplan, Pigment, Adaptive Planning, Cube), close (BlackLine, FloQast, Numeric),
+payments and spend (Bill.com, Ramp, Brex, Tipalti), and cap table (Carta, Pulley) — and
+similar in each.
+
+Know which system is the record for a number before you report it. Two systems that both
+hold a version of revenue will disagree, and the one you quoted will be the wrong one.
+
 ## Never
 
 - Never present a forecast without stating its assumptions and what breaks it

--- a/plugins/finance/skills/financial-reporting-and-close/SKILL.md
+++ b/plugins/finance/skills/financial-reporting-and-close/SKILL.md
@@ -50,6 +50,16 @@ during a crisis.
 Separate **timing** from **run-rate**. A miss caused by something slipping a week is a different
 business fact from a miss caused by demand falling, and conflating them produces the wrong reaction.
 
+## Tooling
+
+Ledger, by scale: QuickBooks, Xero, or FreshBooks for a single entity; NetSuite, Sage
+Intacct, or Dynamics 365 Business Central once you consolidate multiple entities; SAP
+S/4HANA or Oracle Fusion at the top end, and similar.
+
+Close management — BlackLine, FloQast, Numeric, and similar — sits on the ledger and
+tracks the checklist, the reconciliations, and the sign-offs. It buys you an audit trail,
+not discipline. A shared checklist does the same job until the trail is what you lack.
+
 ## Never
 
 - Leave the ledger open for late entries after the stated cutoff.

--- a/plugins/finance/skills/revenue-recognition/SKILL.md
+++ b/plugins/finance/skills/revenue-recognition/SKILL.md
@@ -54,6 +54,14 @@ The deferred balance is work owed, not money banked. Track it by cohort and obli
 answer what it is composed of and when it releases. A balance nobody can decompose is one that
 surprises you.
 
+## Tooling
+
+Subledgers that carry recognition schedules: NetSuite Advanced Revenue Management, Zuora
+Revenue, Maxio, Chargebee, Stripe Revenue Recognition, and similar.
+
+Spreadsheet schedules hold up until contracts carry multiple performance obligations or
+take mid-term modifications. That is the point to move, not a revenue threshold.
+
 ## Never
 
 - Recognize on invoice date or cash receipt as a shortcut.

--- a/plugins/finance/skills/treasury-and-liquidity/SKILL.md
+++ b/plugins/finance/skills/treasury-and-liquidity/SKILL.md
@@ -52,6 +52,16 @@ Do not reach for yield with money you have a date for. The return on operating c
 liquidity risk, and treasury losses of this kind are always described afterwards as conservative
 investments.
 
+## Tooling
+
+Cash visibility and forecasting: Kyriba, Trovata, Tesorio, and similar. Bank portals plus
+a spreadsheet cover a single-bank, single-currency position honestly.
+
+Payments and AP: Bill.com, Tipalti, Ramp, Brex, and similar.
+
+The control that matters is not in the tool list — it is dual approval on payment release,
+by whatever means you get it.
+
 ## Never
 
 - Run the business on an indirect cash forecast.

--- a/plugins/it-operations/skills/backup-and-recovery/SKILL.md
+++ b/plugins/it-operations/skills/backup-and-recovery/SKILL.md
@@ -55,6 +55,16 @@ the only honest input to an RTO, and it is invariably longer than assumed.
 Test the full-scale case at least annually. Restoring one file proves the mechanism; restoring the
 system proves the plan.
 
+## Tooling
+
+Backup platforms: Veeam, Rubrik, Cohesity, Commvault, Acronis, and similar.
+
+SaaS data is the gap people miss. Microsoft 365, Google Workspace, and Salesforce retain
+for a short window and no longer; Veeam, Druva, AvePoint, Keepit, and similar cover it.
+
+The tool is not the control. An untested restore is not a backup, whatever the console
+reports.
+
 ## Never
 
 - Report backup health from job success rather than tested restores.

--- a/plugins/it-operations/skills/cloud-administration/SKILL.md
+++ b/plugins/it-operations/skills/cloud-administration/SKILL.md
@@ -82,6 +82,17 @@ sync. Retention settings are not backups, and the recycle bin is not a recovery 
 deliberately what needs independent protection under `it-operations:backup-and-recovery` rather
 than assuming the vendor's durability promise covers your mistakes.
 
+## Tooling
+
+Platforms: AWS, Microsoft Azure, Google Cloud, and similar.
+
+Infrastructure as code: Terraform, OpenTofu, Pulumi, Bicep, CloudFormation, and similar.
+
+Cost visibility: the native cost tools, or CloudZero, Vantage, Finout, and similar.
+Guardrails: AWS Control Tower, Azure Policy, Wiz, and similar.
+
+Console changes nobody can reproduce in code become the outage you cannot rebuild from.
+
 ## Never
 
 - Buy an application that cannot federate without recording the manual offboarding step.

--- a/plugins/it-operations/skills/endpoint-management/SKILL.md
+++ b/plugins/it-operations/skills/endpoint-management/SKILL.md
@@ -52,6 +52,17 @@ one that gets left in a taxi.
 Departures are coordinated with `people:onboarding-and-offboarding`, with asset return tracked
 against `it-operations:it-asset-management`.
 
+## Tooling
+
+Windows: Microsoft Intune, Configuration Manager, Ivanti, and similar. Apple: Jamf Pro,
+Kandji, Mosyle, and similar. Cross-platform: NinjaOne, Automox, Addigy, and similar.
+
+Endpoint protection: Microsoft Defender for Endpoint, CrowdStrike Falcon, SentinelOne, and
+similar.
+
+Pick for your fleet's majority and accept a second tool for the minority. One tool that
+half-manages both platforms costs more than two that each work.
+
 ## Never
 
 - Allow company data onto a device that never enrolled.

--- a/plugins/it-operations/skills/identity-lifecycle-administration/SKILL.md
+++ b/plugins/it-operations/skills/identity-lifecycle-administration/SKILL.md
@@ -54,6 +54,16 @@ formality that certifies whatever exists.
 Hunt specifically for orphaned accounts — accounts with no owner, service accounts nobody claims,
 and credentials that have not been used in months but still work.
 
+## Tooling
+
+Directory and SSO: Microsoft Entra ID, Okta, Google Workspace, JumpCloud, and similar.
+
+HRIS as the trigger: Workday, BambooHR, Rippling, HiBob, Gusto, ADP, and similar. Identity
+should follow the HRIS record rather than a separate list of who works here.
+
+Provisioning runs on SCIM wherever the application supports it. Where it does not, the
+joiner-mover-leaver steps are manual and belong in a ticket template, not in someone's head.
+
 ## Never
 
 - Provision by copying an existing user.

--- a/plugins/it-operations/skills/service-desk/SKILL.md
+++ b/plugins/it-operations/skills/service-desk/SKILL.md
@@ -82,6 +82,17 @@ Each tier needs its own definition of done. Tier 1 closing a ticket by handing i
 resolved anything, and counting that as a resolution is how a desk reports success while the
 backlog grows one layer up.
 
+## Tooling
+
+ITSM platforms: Jira Service Management, Freshservice, ServiceNow, Ivanti Neurons,
+SolarWinds Service Desk, and similar. ServiceNow is a program rather than a purchase — do
+not take it on without the people to run it.
+
+Remote support: TeamViewer, ScreenConnect, Splashtop, and similar.
+
+Whatever the platform, a ticket has to carry the asset, the person, and a resolution
+category, or the reporting built on it is fiction.
+
 ## Never
 
 - Run parallel unofficial intake channels and treat the ticket queue as the workload.

--- a/plugins/legal-risk/skills/contract-review/SKILL.md
+++ b/plugins/legal-risk/skills/contract-review/SKILL.md
@@ -44,6 +44,16 @@ with pre-approved fallbacks, thresholds below which the business signs without r
 escalation path. Review every contract personally and you become the bottleneck the process was
 meant to prevent.
 
+## Tooling
+
+Contract lifecycle management: Ironclad, Icertis, Agiloft, DocuSign CLM, LinkSquares, and
+similar. Signature alone — DocuSign, Dropbox Sign, PandaDoc — is a different and much
+smaller purchase.
+
+The value in CLM is the clause library and the searchable repository, not the approval
+workflow. If you cannot answer "which of our contracts cap indemnity below the fee paid"
+in a minute, that is the gap worth buying against.
+
 ## Never
 
 - Approve terms whose operational obligations you have not confirmed are achievable.

--- a/plugins/legal-risk/skills/enterprise-risk/SKILL.md
+++ b/plugins/legal-risk/skills/enterprise-risk/SKILL.md
@@ -54,6 +54,16 @@ Leadership needs the few risks whose residual exposure is above appetite, what i
 what needs a decision. Not the whole register. A risk report that requires reading forty rows to
 find the three that matter will not be read.
 
+## Tooling
+
+A risk register is a table, and for most organizations a spreadsheet or a database in
+Notion, Airtable, or Confluence is the honest answer. Dedicated platforms — LogicGate,
+AuditBoard, Riskonnect, ServiceNow IRM, and similar — earn their place when the register
+has to reconcile with audit findings and control testing in one system.
+
+Compliance automation tools cover control evidence, not enterprise risk. Do not let one
+stand in for the other.
+
 ## Never
 
 - Score residual risk on controls that are planned rather than operating.

--- a/plugins/legal-risk/skills/regulatory-compliance/SKILL.md
+++ b/plugins/legal-risk/skills/regulatory-compliance/SKILL.md
@@ -58,6 +58,15 @@ conversation become an undocumented commitment.
 Findings get root-caused like any other failure. A remediation that consists of retraining people on
 a process that made the failure easy will produce the same finding next cycle.
 
+## Tooling
+
+Compliance automation — Vanta, Drata, Secureframe, Keel GRC, and similar — collects
+evidence continuously and maps one control across several frameworks. It earns its cost on
+the second audit far more often than the first.
+
+Policy and attestation lives in those same tools, or in the HRIS, or in Confluence. What
+matters is that a policy carries a version, an owner, and a record of who acknowledged it.
+
 ## Never
 
 - Treat a certification as evidence of legal compliance.

--- a/plugins/operations/skills/procurement-and-sourcing/SKILL.md
+++ b/plugins/operations/skills/procurement-and-sourcing/SKILL.md
@@ -55,6 +55,16 @@ deciding that trade.
 Route the resulting terms through `legal-risk:contract-review`, and anything touching customer data
 through `legal-risk:privacy-and-data-protection` before signature rather than after.
 
+## Tooling
+
+Procure-to-pay: Coupa, SAP Ariba, Zip, Precoro, and similar. At smaller scale a request
+form plus the accounting system's purchase orders does the same work.
+
+Spend visibility: Ramp, Brex, Vertice, and similar, read against the ledger.
+
+Vendor risk lives in the GRC tooling, not here — but the intake form is where the security
+and privacy review has to be triggered, or it never happens.
+
 ## Never
 
 - Write a requirement that only the preferred supplier can meet.

--- a/plugins/people/skills/onboarding-and-offboarding/SKILL.md
+++ b/plugins/people/skills/onboarding-and-offboarding/SKILL.md
@@ -56,6 +56,17 @@ Exit conversations produce candid information that is unavailable any other way,
 collected and never used. Aggregate themes over time and look by manager and by team; a single exit
 is an anecdote, a pattern across four is a finding for `people:chief-human-resources-officer`.
 
+## Tooling
+
+HRIS as the record of who works here and when they started or left: Workday, BambooHR,
+Rippling, HiBob, Gusto, ADP, and similar.
+
+Onboarding workflow: the HRIS's own, or Sapling, Enboarder, or a checklist in the ticketing
+system, and similar.
+
+Offboarding has to reach identity, devices, and payroll the same day. Whatever the tools,
+one owner runs the checklist end to end. Split ownership is how accounts stay live.
+
 ## Never
 
 - Let a start date arrive without access and equipment confirmed ready.

--- a/plugins/pmo/skills/project-delivery/SKILL.md
+++ b/plugins/pmo/skills/project-delivery/SKILL.md
@@ -57,6 +57,17 @@ Then present options with consequences — cut scope and name what, extend and s
 capacity, which late in a project usually slows things further. Re-baseline once, visibly. Serial
 one-week slips destroy credibility far faster than a single honest reset.
 
+## Tooling
+
+Delivery tracking: Jira, Asana, Linear, Monday.com, Smartsheet, Microsoft Project, and
+similar.
+
+Portfolio and capacity: Jira Align, Planview, Adaptive Work, and similar. Worth it when you
+are reconciling many teams' plans against one capacity pool, not before.
+
+The tool records the plan; it does not make the plan true. A status field nobody updates
+between meetings is worse than no field at all.
+
 ## Never
 
 - Agree scope without written exclusions.

--- a/plugins/product/skills/design-system/SKILL.md
+++ b/plugins/product/skills/design-system/SKILL.md
@@ -41,6 +41,15 @@ a polish item; it is whether people can use it.
 - Never remove a token or component because it looks unused. You cannot see every consumer from
   inside the system. Deprecate, announce, then remove.
 
+## Tooling
+
+Design source: Figma, and similar. Component documentation and review: Storybook.
+
+Token pipelines: Style Dictionary, Tokens Studio, Figma variables exported to code, and
+similar. Visual regression: Chromatic, Percy, Playwright snapshots, and similar.
+
+The system is the code, not the design file. When the two disagree, the code is what ships.
+
 ## Never
 
 - Add a component for a single screen. A one-use component is a snippet, not a system.

--- a/plugins/revenue/skills/outbound-prospecting/SKILL.md
+++ b/plugins/revenue/skills/outbound-prospecting/SKILL.md
@@ -56,6 +56,16 @@ Use a subdomain for outbound so a reputation problem cannot take down your trans
 - **Replies, no meetings** — a qualification problem: you are reaching people who cannot act.
 - **Meetings, no pipeline** — the segment is wrong.
 
+## Tooling
+
+Sequencing: Outreach, Salesloft, Apollo, Lemlist, Instantly, and similar.
+
+Contact data: ZoomInfo, Apollo, Clay, LinkedIn Sales Navigator, and similar. Every
+provider's data decays; verify before you send, whichever you buy.
+
+Deliverability: a separate sending domain, plus warmup and monitoring — Instantly,
+Smartlead, Google Postmaster Tools, and similar.
+
 ## Never
 
 - Send before the list is qualified. A good message to the wrong person is still a bad message.

--- a/plugins/revenue/skills/revenue-operations/SKILL.md
+++ b/plugins/revenue/skills/revenue-operations/SKILL.md
@@ -71,6 +71,16 @@ be unusable within two quarters.
 Never require a field whose value is not used in a decision. Every unnecessary field trains sellers
 to enter garbage in all of them.
 
+## Tooling
+
+CRM: Salesforce, HubSpot, Pipedrive, Zoho CRM, and similar. The CRM is the record for
+pipeline. Anything that disagrees with it is a report, not a number.
+
+Enrichment and routing: Clay, ZoomInfo, Apollo, Chili Piper, and similar.
+
+Forecasting and conversation data: Clari, Gong, and similar — useful once you have enough
+deals for a pattern to mean anything.
+
 ## Never
 
 - Change a definition without restating history on the new one. A metric that moved because you redefined it is not a result.

--- a/plugins/security/skills/access-and-identity/SKILL.md
+++ b/plugins/security/skills/access-and-identity/SKILL.md
@@ -65,6 +65,16 @@ Look for: permissions granted to individuals rather than roles, roles nobody can
 administrative access, accounts whose owner has left, service credentials with no owner, and systems
 outside SSO. Each is a specific fix, and the list is nearly always the same list.
 
+## Tooling
+
+Identity providers: Okta, Microsoft Entra ID, Google Workspace, JumpCloud, and similar.
+
+Privileged access and secrets: CyberArk, HashiCorp Vault, 1Password, Doppler, and similar.
+
+Access reviews and provisioning: Okta Identity Governance, Entra ID Governance, Lumos,
+ConductorOne, and similar. Worth buying at the point a manual quarterly review stops
+finishing rather than the point it gets tedious.
+
 ## Never
 
 - Grant standing access where time-bound access would do the same job.

--- a/plugins/security/skills/security-architecture-review/SKILL.md
+++ b/plugins/security/skills/security-architecture-review/SKILL.md
@@ -52,6 +52,10 @@ implements a comparison, a token, or a signature by hand.
 - **DAST** and dependency scanning find different things; neither replaces review.
 - **Secret scanning in CI and pre-commit** is the highest-value automation per unit of effort.
 
+By name today: Semgrep, CodeQL, or SonarQube for SAST; Snyk, Dependabot, or Trivy for
+dependencies; Burp Suite or OWASP ZAP for DAST; gitleaks, TruffleHog, or GitHub secret
+scanning for secrets — and similar in each category.
+
 Automation is a floor, not a review. It finds known patterns, not design flaws — and design flaws
 are what actually cause the expensive incidents.
 

--- a/plugins/security/skills/vulnerability-management/SKILL.md
+++ b/plugins/security/skills/vulnerability-management/SKILL.md
@@ -67,6 +67,15 @@ good-faith reporter as an adversary is how a private report becomes a public one
 Leadership needs: what is exposed and unfixed past SLA, the trend, and what needs a decision. Not
 the count of findings, which mostly measures how much you scanned.
 
+## Tooling
+
+Infrastructure scanning: Tenable, Qualys, Rapid7 InsightVM, and similar. Code and
+dependencies: Snyk, Dependabot, GitHub Advanced Security, Semgrep, Trivy, and similar.
+Cloud posture: Wiz, Orca, Prisma Cloud, and similar.
+
+Exploitability context — the CISA KEV catalog, EPSS scores — decides what you fix first.
+The scanner only decides what you know about.
+
 ## Never
 
 - Rank on CVSS alone. A score is not exploitability in your environment.

--- a/plugins/technology/skills/observability-and-reliability/SKILL.md
+++ b/plugins/technology/skills/observability-and-reliability/SKILL.md
@@ -54,6 +54,16 @@ defect, and it is the part that repeats.
 Produce a small number of real actions with owners and dates. A review generating fifteen actions
 generates none.
 
+## Tooling
+
+Metrics and traces: Datadog, Grafana with Prometheus, New Relic, Honeycomb, and similar.
+Errors: Sentry, Rollbar, and similar. Logs: Elastic, OpenSearch, Loki, Splunk, and similar.
+
+On-call and incident management: PagerDuty, Opsgenie, incident.io, FireHydrant, and similar.
+
+Instrument with OpenTelemetry wherever you can. Vendor-specific instrumentation is the part
+that makes leaving expensive.
+
 ## Never
 
 - Page a human for something they cannot act on.


### PR DESCRIPTION
Follow-on to #24, which merged before this commit landed. Same work, rebased onto current `main`.

## What this changes

Adds a `## Tooling` section naming actual products to the 28 skills where the tool choice is part of doing the work.

"CRM familiarity" tells a non-expert nothing. "Salesforce, HubSpot, Pipedrive, Zoho CRM, and similar" tells them what to look for and what they are looking at.

## Two conventions, applied consistently

**Every list closes with "and similar."** The list is illustrative — not a recommendation, and not an attempted survey of the category.

**A rough scale tier appears only where scale changes the answer.** The finance ledger (QuickBooks/Xero single-entity → NetSuite/Sage Intacct/Dynamics 365 multi-entity → SAP or Oracle at the top), FP&A planning, revenue recognition subledgers, portfolio management, access review tooling. Everywhere else the options sit at the same tier and a tier would be noise.

## Categories covered

Accounting ledgers and close management, FP&A planning, revenue recognition, treasury and AP, GRC and compliance automation, contract lifecycle management, vulnerability scanning, identity and privileged access, support ticketing, ITSM, endpoint management, HRIS, backup including the SaaS retention gap, cloud platforms and infrastructure as code, CRM and sales engagement, marketing analytics and lifecycle automation, BI and semantic layers, warehouses and ingestion, delivery tracking, observability and on-call, design systems, and procure-to-pay.

Finance is split across five skills rather than concentrated in one, because the tools are not interchangeable across close, planning, recognition, and treasury — and the CFO skill carries the whole stack by layer, since that is the role that has to know which system is the record for which number.

`security-architecture-review` already had a `## Tooling` section written by category, so the product names went into it rather than beside it.

## Each section closes on what the tool cannot supply

An untested restore is not a backup, whatever the console reports. The CRM is the record for pipeline; anything that disagrees with it is a report, not a number. The design system is the code, not the design file. Without that, a tool list reads as a shopping list.

A few draw boundaries that are easy to get wrong: compliance automation covers control evidence, not enterprise risk; transactional sending belongs off the marketing domain; SaaS vendors retain for a short window and do not back your data up.

## Placement

`## Tooling` goes before `## Never`, so the failure modes still close the file.

## Verification

`scripts/check-all.sh` — all nine checks pass on the rebased branch.

## Maintenance note

Named products date faster than the guidance around them. The "and similar" close and the by-category framing keep a stale name from reading as a stale recommendation, but this is the part of the library that will need periodic revisiting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_