### PR TITLE
Name software tools on 20 more skills

### DIFF
--- a/plugins/customer-experience/skills/customer-success-management/SKILL.md
+++ b/plugins/customer-experience/skills/customer-success-management/SKILL.md
@@ -74,6 +74,15 @@ thing that leads to the next thing, added a team. Expansion pushed on a quota ca
 account that has not realized its original purchase is how a renewal gets lost while chasing a
 smaller number.
 
+## Tooling
+
+Customer success platforms: Gainsight, Totango, ChurnZero, Vitally, Planhat, and similar. They
+earn their cost once you have more accounts than a person can hold in their head and product usage
+data worth joining to the account record — before that, the CRM plus a usage query does the job.
+
+Renewal and expansion tracking belongs in the CRM alongside new business, not in a separate system,
+or the forecast will exist twice and disagree.
+
 ## Never
 
 - Run a health score nobody has validated against actual outcomes.

--- a/plugins/customer-experience/skills/voice-of-customer/SKILL.md
+++ b/plugins/customer-experience/skills/voice-of-customer/SKILL.md
@@ -57,6 +57,17 @@ why it works — it converts a complainer into someone who reports the next issu
 Also close it internally: show the support team what shipped because of what they escalated, or they
 stop escalating.
 
+## Tooling
+
+Survey and feedback: Qualtrics, Medallia, Delighted, SurveyMonkey, Typeform, and similar.
+
+In-product feedback and micro-surveys: Pendo, Sprig, Chameleon, and similar — usually a better
+signal than emailed surveys because they reach people mid-task rather than after the fact.
+
+Aggregating unstructured feedback across tickets, calls and reviews is where the platforms differ
+most. Whatever collects it, the theme has to be traceable back to individual verbatims, or nobody
+downstream will believe the count.
+
 ## Never
 
 - Report themes without volume.

--- a/plugins/demand-generation/skills/app-store-optimization/SKILL.md
+++ b/plugins/demand-generation/skills/app-store-optimization/SKILL.md
@@ -47,6 +47,18 @@ Watch review text for recurring themes — it is the cheapest continuous product
 Change one element at a time and let it run a full weekly cycle; app traffic is strongly
 day-of-week seasonal. Attributing a lift to the wrong change is worse than not testing.
 
+## Tooling
+
+The consoles are the source of truth: App Store Connect and Google Play Console, including their
+own experiment features — product page optimization and store listing experiments — which test on
+real store traffic rather than a simulation.
+
+Keyword and competitor research: AppTweak, Sensor Tower, data.ai, AppFollow, and similar. Treat
+their volume estimates as directional; the stores do not publish the underlying numbers.
+
+Review management and reply workflows live in the consoles or in the same tools, and replying is
+the part most teams skip.
+
 ## Never
 
 - Chase a keyword the app does not deliver on. Installs from a mismatched query become one-star reviews and a worse ranking than you started with.

--- a/plugins/demand-generation/skills/experimentation/SKILL.md
+++ b/plugins/demand-generation/skills/experimentation/SKILL.md
@@ -47,6 +47,19 @@ tests a year — spend them on structural questions, not button colors.
 Keep a log of every test: hypothesis, result, decision. Without it, teams re-run the same tests every
 eighteen months and re-learn the same things.
 
+## Tooling
+
+Client-side and web testing: Optimizely, VWO, AB Tasty, and similar. Warehouse- or
+product-native: GrowthBook, Statsig, Eppo, PostHog, and similar — these compute against your own
+event data, which is what you want once the metric definitions matter.
+
+Feature flags are the server-side path to the same thing: LaunchDarkly, Unleash, Split, and similar.
+Running an experiment behind a flag you already use for release control is cheaper than adding a
+second system, and `technology:release-and-deployment` covers the release side of it.
+
+No tool fixes an underpowered test. The platform reports a result either way, which is exactly the
+risk.
+
 ## Never
 
 - Stop a test because it reached significance early. Peeking until it looks conclusive manufactures the result.

--- a/plugins/demand-generation/skills/paid-advertising/SKILL.md
+++ b/plugins/demand-generation/skills/paid-advertising/SKILL.md
@@ -60,6 +60,18 @@ conversion rate (is the page delivering), cost per acquisition (is it economic),
 quality (did those customers stay). Stopping at cost per acquisition is how channels get scaled that
 are buying bad customers cheaply.
 
+## Tooling
+
+The platforms themselves: Google Ads, Meta Ads Manager, LinkedIn Campaign Manager, Microsoft
+Advertising, TikTok Ads Manager, Reddit Ads, and similar. Each has its own definition of a
+conversion, and reconciling them against one internal definition is most of the analytics work.
+
+Management and automation layers — Skai, Optmyzr, Smartly, and similar — are worth it at spend
+levels where a full-time person could not manually cover the account structure, and not before.
+
+Creative volume is the constraint more often than bidding. Budget for producing variants at the
+rate the platform consumes them.
+
 ## Never
 
 - Scale a campaign on a few conversions. Wait for significance.

--- a/plugins/it-operations/skills/it-asset-management/SKILL.md
+++ b/plugins/it-operations/skills/it-asset-management/SKILL.md
@@ -50,6 +50,20 @@ Disposal is where data escapes. Require certified destruction or verified wipe, 
 and treat storage devices as data until proven otherwise. A drive in a cupboard nobody logged is a
 breach with no date attached.
 
+## Tooling
+
+Discovery and hardware inventory: Lansweeper, Snipe-IT, ServiceNow ITAM, Device42, and similar;
+the endpoint management platform already knows most of the fleet and is the cheapest starting
+point.
+
+Software licensing and SaaS spend: Flexera, Torii, Zylo, Productiv, and similar. The SaaS half is
+where the money hides, and it is discovered through the expense system and single sign-on logs as
+much as through any inventory tool.
+
+Reconcile the register against the endpoint platform, the identity provider and the finance system
+on a schedule. Three systems each holding a partial truth is the normal state, and the gaps between
+them are the assets nobody is managing.
+
 ## Never
 
 - Maintain a register by hand and trust it.

--- a/plugins/marketing/skills/events-and-field-marketing/SKILL.md
+++ b/plugins/marketing/skills/events-and-field-marketing/SKILL.md
@@ -55,6 +55,18 @@ Track influenced pipeline with the assumption stated, alongside the honest direc
 compare cost per opportunity against your other channels through
 `demand-generation:marketing-analytics`.
 
+## Tooling
+
+Event and webinar platforms, roughly by scale: Luma or Zoom Webinars for small and recurring
+formats; Goldcast, ON24 or Bizzabo where the recording and the follow-up data matter; Cvent for
+large multi-track events, and similar.
+
+Lead capture at physical events: the organizer's badge scanning, or your own — and whichever it is,
+test the export path into the CRM before the event rather than discovering the format afterward.
+
+The tooling that actually decides the outcome is the follow-up sequence, which lives in your
+lifecycle platform and should be built before the event opens.
+
 ## Never
 
 - Sponsor an event without a single stated goal.

--- a/plugins/marketing/skills/public-relations/SKILL.md
+++ b/plugins/marketing/skills/public-relations/SKILL.md
@@ -47,6 +47,18 @@ explicitly agreed in advance — and even then, assume it may not hold.
 - Correct genuine errors privately, with evidence, and specifically. Vague complaints about tone
   achieve nothing.
 
+## Tooling
+
+Media databases and pitching: Muck Rack, Cision, Prowly, Roxhill, and similar. They are expensive,
+and their value is contact accuracy and beat data rather than the ability to send in bulk — a
+list-blast through one of them is the fastest way to be ignored by the journalists on it.
+
+Wire distribution: Business Wire, PR Newswire, and similar. A wire buys disclosure and syndication,
+not coverage; treat it as a compliance or record-keeping tool unless you have a reason otherwise.
+
+Monitoring: Meltwater, Brandwatch, Google Alerts, and similar. Set it up before the story you need
+to see, not after.
+
 ## Never
 
 - Pitch a story that is only news to you. A funding round, a hire, and a redesign are not news outside the company.

--- a/plugins/marketing/skills/social-post-craft/SKILL.md
+++ b/plugins/marketing/skills/social-post-craft/SKILL.md
@@ -52,6 +52,15 @@ most platforms strip formatting.
 
 A draft that fails these gets rewritten, not published with a caveat.
 
+## Tooling
+
+Scheduling and publishing: Buffer, Hootsuite, Later, Sprout Social, Typefully, and similar. Native
+composers usually get better reach handling and newer formats first, so schedule what benefits from
+timing and post natively what benefits from features.
+
+Whatever you use, keep the draft somewhere the copy can be reviewed before it enters the scheduler.
+Editing inside a publishing queue is how a typo goes out at 6am.
+
 ## Never
 
 - Publish a post whose first line only works after the reader expands it.

--- a/plugins/marketing/skills/video-content/SKILL.md
+++ b/plugins/marketing/skills/video-content/SKILL.md
@@ -50,6 +50,17 @@ Plan derivatives before filming, not after. Segments intended to stand alone get
 alone. Extracting short-form from a video not built for it produces clips that need context they do
 not have.
 
+## Tooling
+
+Editing: DaVinci Resolve, Adobe Premiere Pro, Final Cut Pro, CapCut, and similar; Descript for
+transcript-driven editing, which is faster for talking-head and interview formats than a timeline.
+
+Recording remote: Riverside, Zoom, StreamYard, and similar — record local tracks per participant
+where the tool supports it, because the connection quality on the day decides the ceiling otherwise.
+
+Repurposing and captions: Opus Clip, Submagic, and similar. Burned-in captions are not optional;
+most viewing is silent, and the caption is the packaging on every platform that autoplays.
+
 ## Never
 
 - Produce before the title and thumbnail exist. Packaging decides whether anything you shot gets seen.

--- a/plugins/operations/skills/business-continuity-and-resilience/SKILL.md
+++ b/plugins/operations/skills/business-continuity-and-resilience/SKILL.md
@@ -53,6 +53,19 @@ region, redundant network paths in the same physical duct, a manual workaround t
 system you have just lost. Map dependencies to the point where they stop being yours, and check
 whether the redundancy is real or just contractual.
 
+## Tooling
+
+Continuity and crisis management platforms: Fusion Framework, Castellan, Riskonnect, and similar.
+They hold the impact analysis, the plans, and the exercise record in one place, and they are worth
+buying at the point where the plans are too many for one person to keep current.
+
+Mass notification: Everbridge, AlertMedia, and similar — the capability being bought is reaching
+people when your own email and chat are the thing that is down, which is the scenario a plan stored
+only in those systems fails.
+
+Keep an offline copy of the plan and the contact list. Every organization that has run a real
+incident has a story about the plan being inside the system that was unavailable.
+
 ## Never
 
 - Set an RTO without the process owner agreeing to what it costs.

--- a/plugins/operations/skills/quality-management/SKILL.md
+++ b/plugins/operations/skills/quality-management/SKILL.md
@@ -52,6 +52,19 @@ and pair any rate metric with a volume metric so improvement by doing less is vi
 
 Escaped defects — those the customer found — are the honest measure. Everything else is a proxy.
 
+## Tooling
+
+A quality management system is a regulatory purchase before it is an operational one. Greenlight
+Guru, Qualio, MasterControl, ETQ and similar exist because regulated industries need document
+control, training records and corrective actions in an auditable system. Outside those industries
+a well-run issue tracker and a document repository cover the same ground.
+
+Corrective and preventive action tracking is the part worth having in one place regardless of tool,
+because the recurring finding is always an action from last time that was never closed.
+
+Statistical process control needs measurement more than software. A control chart in a spreadsheet
+built on real measurements beats a platform fed by nobody.
+
 ## Never
 
 - Attribute a defect to carelessness and stop there.

--- a/plugins/people/skills/compensation-and-leveling/SKILL.md
+++ b/plugins/people/skills/compensation-and-leveling/SKILL.md
@@ -54,6 +54,18 @@ cycle. Findings here need qualified review before action.
   counteroffer is right, it should reflect a correction you should have already made.
 - Every exception is a precedent. Document the reasoning, because you will be asked to repeat it.
 
+## Tooling
+
+Benchmark data is the purchase that matters, and it is where the scale tier is real: free and
+crowd-sourced ranges are directional at best; Pave, Carta Total Comp or Option Impact suit venture
+-backed companies; Radford, Mercer or Willis Towers Watson are the surveys large employers price
+against, and similar.
+
+Administration: the compensation module of the HRIS, or CompTrack, Assemble, and similar.
+
+Whatever the source, know its effective date, its scope, and how it defines the level you are
+matching to. Two surveys disagreeing usually means they are describing different jobs.
+
 ## Never
 
 - Set an individual's pay before their level is settled.

--- a/plugins/people/skills/hiring-and-interviewing/SKILL.md
+++ b/plugins/people/skills/hiring-and-interviewing/SKILL.md
@@ -50,6 +50,17 @@ is missing, get it — an extra conversation is cheap compared to a mis-hire.
 Ambiguity means no. The cost of a bad hire is far larger and lasts far longer than the cost of a
 longer search, and it is borne by the team, not the hiring manager.
 
+## Tooling
+
+Applicant tracking, roughly by scale: Workable, JazzHR or the hiring module of an all-in-one HRIS
+at small scale; Greenhouse, Lever or Ashby once structured interviewing and reporting matter;
+Workday Recruiting or SmartRecruiters at enterprise scale, and similar.
+
+Sourcing and scheduling: LinkedIn Recruiter, Gem, GoodTime, and similar.
+
+Put the scorecard in the tracking system rather than beside it. A structured process that lives in
+a separate document is a structured process that stops being followed in the first busy week.
+
 ## Never
 
 - Lower the bar because the search has been long. Reopen the role definition instead.

--- a/plugins/people/skills/learning-and-development/SKILL.md
+++ b/plugins/people/skills/learning-and-development/SKILL.md
@@ -51,6 +51,18 @@ Fix the incentive rather than the policy: make developing and releasing people s
 evaluated on. A mobility policy that costs a manager their best person and gives them nothing will be
 quietly resisted, and quiet resistance always wins.
 
+## Tooling
+
+Delivery: TalentLMS, Docebo, WorkRamp, Absorb, and similar; smaller organizations often do better
+with a structured path built in the tools people already use than with a platform nobody visits.
+
+Content libraries: LinkedIn Learning, Coursera, Pluralsight, Udemy Business, and similar. Licensed
+libraries buy breadth and almost never buy transfer — completion rates on self-serve content are
+low everywhere, and the ones that work are assigned against a named capability gap.
+
+Skills and career frameworks: the HRIS's own, or a maintained document. The framework matters more
+than the software holding it.
+
 ## Never
 
 - Deliver training for a problem that is not a capability problem.

--- a/plugins/people/skills/performance-management/SKILL.md
+++ b/plugins/people/skills/performance-management/SKILL.md
@@ -59,6 +59,17 @@ Where a formal plan is warranted it needs specific outcomes, a real timeframe, d
 stated consequence. A plan that is only a paper trail for a decision already taken is recognized as
 such and does damage well beyond the individual.
 
+## Tooling
+
+Review and feedback: Lattice, Culture Amp, 15Five, Leapsome, Workday Talent, and similar.
+
+Engagement measurement usually ships in the same platforms, which is convenient and creates a
+temptation worth resisting: engagement data and performance data should not be joined at the
+individual level, because people answer honestly only while that is true.
+
+The tool cannot fix a process problem. If reviews are late, unspecific, or a surprise to the person
+receiving them, changing platforms will produce the same reviews on a nicer form.
+
 ## Never
 
 - Assess against expectations that were not set in advance.

--- a/plugins/revenue/skills/sales-compensation-and-territory/SKILL.md
+++ b/plugins/revenue/skills/sales-compensation-and-territory/SKILL.md
@@ -71,6 +71,18 @@ Mid-period changes are occasionally necessary and always expensive in trust. Giv
 the reason, and never restate a commission already earned under the prior plan. A team that
 believes the plan can be changed retroactively stops treating it as an incentive.
 
+## Tooling
+
+Commission calculation: CaptivateIQ, Spiff, Everstage, Xactly, and similar. The threshold for
+buying is not headcount, it is the point at which a spreadsheet error would go unnoticed — which
+arrives earlier than most teams expect.
+
+Territory and quota planning: Fullcast, Salesforce Maps, Varicent, and similar; a well-built model
+covers a single-segment team.
+
+Whatever calculates it, reps need a statement they can check themselves. Disputes are expensive in
+trust long before they are expensive in money.
+
 ## Never
 
 - Assign a quota to a territory that cannot mathematically support it.

--- a/plugins/technology/skills/api-design/SKILL.md
+++ b/plugins/technology/skills/api-design/SKILL.md
@@ -51,6 +51,18 @@ offset pagination silently skips and duplicates records under concurrent writes.
 State rate limits in the contract and communicate them in responses. An undocumented limit is
 discovered in the consumer's production incident.
 
+## Tooling
+
+Specification and documentation: OpenAPI with Redocly, Stoplight, or Scalar; gRPC with protocol
+buffers where the consumers are internal services, and similar.
+
+Design review and testing: Postman, Insomnia, Bruno, and similar. Contract testing — Pact and
+similar — is what catches a breaking change before a consumer does.
+
+Generate the documentation from the specification and the specification from or alongside the code.
+Hand-maintained API documentation is wrong within a release, and being confidently wrong is worse
+for a consumer than being absent.
+
 ## Never
 
 - Expose internal identifiers or storage structure through the interface.

--- a/plugins/technology/skills/cloud-infrastructure/SKILL.md
+++ b/plugins/technology/skills/cloud-infrastructure/SKILL.md
@@ -57,6 +57,19 @@ tagging, cost becomes an unattributable aggregate that only ever gets addressed 
 The usual large wins are unglamorous: idle non-production resources, over-provisioned instances,
 storage nobody deleted, and cross-zone data transfer nobody accounted for.
 
+## Tooling
+
+Platforms: AWS, Google Cloud, Microsoft Azure, and similar; managed application platforms —
+Fly.io, Render, Vercel, Railway — remove most of this work and are the right answer more often than
+engineering pride admits.
+
+Orchestration where you need it: Kubernetes with a managed control plane, or a container service
+like ECS. Kubernetes is a platform team's worth of work; adopt it when you have the team.
+
+Infrastructure as code and secrets: Terraform, OpenTofu, Pulumi, and similar, with secrets in a
+managed store rather than in the state file. `it-operations:cloud-administration` covers the
+corporate cloud estate, which is a different problem with overlapping tools.
+
 ## Never
 
 - Make a production change by hand that is not reflected in code.

--- a/plugins/technology/skills/release-and-deployment/SKILL.md
+++ b/plugins/technology/skills/release-and-deployment/SKILL.md
@@ -50,6 +50,17 @@ of both shapes throughout.
 Test the migration against production-scale data. A migration that is instant on a development
 dataset can lock a large table for a length of time nobody modeled.
 
+## Tooling
+
+Pipelines: GitHub Actions, GitLab CI, CircleCI, Buildkite, Jenkins, and similar.
+
+Continuous delivery and progressive rollout: Argo CD, Flux, Spinnaker, and similar; feature flags
+for decoupling deploy from release — LaunchDarkly, Unleash, Split, and similar.
+
+Schema migrations: Flyway, Liquibase, Alembic, and similar. Whichever you use, the property that
+matters is that migrations are versioned, ordered, and applied by the pipeline rather than by a
+person with a database client.
+
 ## Never
 
 - Couple deploying code to exposing behavior.


### PR DESCRIPTION
Stacked on #29 — merge that first and this retargets to `main` automatically.

Finishes the tooling pass. **Coverage goes from 28 of 172 to 48.** Same two conventions as the first pass: every list closes with **"and similar"**, and a **scale tier** appears only where scale changes the answer.

## By department

**people** — `hiring-and-interviewing` (applicant tracking, tiered; a scorecard living outside the tracking system stops being used in the first busy week), `compensation-and-leveling` (benchmark data is the real purchase, and the tier here is genuinely wide — crowd-sourced to Radford), `learning-and-development` (licensed libraries buy breadth and almost never buy transfer), `performance-management` (engagement and performance data should not be joined at the individual level — people answer honestly only while that's true).

**customer-experience** — `voice-of-customer` (in-product micro-surveys beat emailed ones because they arrive mid-task), `customer-success-management`.

**revenue** — `sales-compensation-and-territory` (the buying threshold isn't headcount, it's the point where a spreadsheet error would go unnoticed — which arrives earlier than teams expect).

**demand-generation** — `experimentation` (warehouse-native vs client-side, and feature flags as the server-side path to the same thing), `paid-advertising` (each platform defines a conversion differently; reconciling them against one internal definition is most of the analytics work), `app-store-optimization` (the consoles' own experiments run on real store traffic rather than a simulation).

**technology** — `release-and-deployment`, `api-design` (generate docs from the spec — hand-maintained API documentation is wrong within a release, and confidently wrong is worse for a consumer than absent), `cloud-infrastructure` (managed platforms are the right answer more often than engineering pride admits; Kubernetes is a platform team's worth of work).

**operations** — `quality-management` (a QMS is a regulatory purchase before an operational one — outside regulated industries an issue tracker covers the same ground), `business-continuity-and-resilience` (mass notification exists for when your own email is the thing that's down, which is exactly why the plan can't live only there).

**it-operations** — `it-asset-management` (the SaaS half is where the money hides, found through expense and SSO logs as much as any inventory tool).

**marketing** — `social-post-craft`, `public-relations` (media databases sell contact accuracy, not bulk send — a list-blast through one is the fastest way to be ignored by the journalists on it), `events-and-field-marketing` (test the badge-scan export into the CRM *before* the event), `video-content` (burned-in captions are packaging, not accessibility garnish).

## What was deliberately left alone

Skills where naming products would duplicate a neighbor — PMO delivery tools already sit in `project-delivery`, email service providers in `lifecycle-messaging` — or where the category is too thin to be worth a section. `threat-modeling` is one of those: the dedicated tools are niche enough that naming them would mislead more than help.

## Verification

`scripts/check-all.sh` — all nine checks pass, including the widened reference check from #29 at 247 references.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQP2WCqeFYH7s9pi1CJ5u)_