### PR TITLE
fix: repair split bullets in four chief-* Never lists, close utilisation lint gap

### DIFF
--- a/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
+++ b/plugins/corporate-strategy/skills/chief-strategy-officer/SKILL.md
@@ -86,11 +86,11 @@ attached is a hobby.
 
 - Confuse a plan with a strategy. A sequence of initiatives is not a choice about where to compete.
 - Pursue an acquisition because it is available rather than because it serves a thesis written
-- Do not call a strategy decided until the resourcing artifacts moved
-- Do not produce a competitive map that answers no pending question
   beforehand.
 - Let a strategy survive an assumption being falsified. When the thing you bet on turns out untrue,
   say so and revise.
+- Do not call a strategy decided until the resourcing artifacts moved
+- Do not produce a competitive map that answers no pending question
 
 ## Return contract
 

--- a/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
+++ b/plugins/customer-experience/skills/chief-customer-officer/SKILL.md
@@ -74,11 +74,11 @@ rather than a support problem — and this role decides which it is.
 ## Never
 
 - Let a recurring issue stay a support workaround because a fix is inconvenient. Count the contacts
-- Do not report themes where the unit that can be acted on is a mechanism
-- Do not keep escalating a finding the organization has decided not to fix
   and put the number in front of the decision.
 - Measure the team on speed alone. Time-to-close optimizes for closing, not for solving.
 - Promise a customer something the delivering team has not agreed to.
+- Do not report themes where the unit that can be acted on is a mechanism
+- Do not keep escalating a finding the organization has decided not to fix
 
 ## Return contract
 

--- a/plugins/data-analytics/skills/chief-data-officer/SKILL.md
+++ b/plugins/data-analytics/skills/chief-data-officer/SKILL.md
@@ -91,12 +91,12 @@ covers it.
 
 - Let a metric be defined by whoever reports it.
 - Ship a model with no evaluation set and no monitoring. It will degrade, and you will find out
-- Do not arbitrate a number dispute without fixing the definition behind it
-- Do not treat pipeline health checks as evidence the data answered the question
-- Do not deploy a consequential model before the policy governing it exists
   from a customer.
 - Grant access to a dataset without knowing what is in it.
 - Present a number without its definition attached when the definition is contested.
+- Do not arbitrate a number dispute without fixing the definition behind it
+- Do not treat pipeline health checks as evidence the data answered the question
+- Do not deploy a consequential model before the policy governing it exists
 
 ## Return contract
 

--- a/plugins/operations/skills/capacity-and-demand-planning/SKILL.md
+++ b/plugins/operations/skills/capacity-and-demand-planning/SKILL.md
@@ -32,7 +32,7 @@ ordinary week.
 
 ## Queues tell you before the dashboard does
 
-Utilisation above roughly 80% makes wait times rise sharply and non-linearly — a system at 95% is not
+Utilization above roughly 80% makes wait times rise sharply and non-linearly — a system at 95% is not
 slightly slower than one at 85%, it is qualitatively worse. This is why "we have spare capacity on
 paper" coexists with a queue that never clears.
 
@@ -43,7 +43,7 @@ getting older is a queue that is quietly failing its slowest customers.
 
 Before adding capacity, establish which it is:
 
-- **Genuine capacity shortfall** — arrival rate exceeds service rate at reasonable utilisation. Add
+- **Genuine capacity shortfall** — arrival rate exceeds service rate at reasonable utilization. Add
   capacity.
 - **Flow problem** — rework, handoffs, waiting on another team, batching. Adding capacity here adds
   cost and often makes throughput worse by increasing coordination. Send this to
@@ -54,6 +54,6 @@ The tell: if work spends most of its life waiting rather than being worked, it i
 ## Never
 
 - Plan against nominal headcount rather than effective capacity.
-- Run a critical queue at sustained high utilisation and treat the wait times as a mystery.
+- Run a critical queue at sustained high utilization and treat the wait times as a mystery.
 - Add capacity to a process you have not measured.
 - Forecast in aggregate currency when work arrives in discrete units.

--- a/plugins/security/skills/chief-information-security-officer/SKILL.md
+++ b/plugins/security/skills/chief-information-security-officer/SKILL.md
@@ -114,12 +114,11 @@ consequence — breach notification in particular runs on statutory clocks measu
 - Approve an exception without an expiry date and a named owner.
 - Let "we'll fix it post-launch" stand without it being recorded as accepted risk.
 - Treat a passed audit as evidence of security. Audits test whether controls exist as documented,
-- Do not block without stating exactly what unblocks it
-- Do not let an override happen without a recorded, named risk acceptance
-- Do not fix another team's finding for them and leave the cause in place
   which is a different question from whether they work.
 - Block without saying what would unblock. A security function that only says no gets routed around,
   and then it sees nothing.
+- Do not let an override happen without a recorded, named risk acceptance
+- Do not fix another team's finding for them and leave the cause in place
 
 ## Return contract
 

--- a/scripts/check-us-english.py
+++ b/scripts/check-us-english.py
@@ -55,6 +55,7 @@ PAIRS = {
     "authorisation": "authorization",
     "customise": "customize", "customised": "customized",
     "utilise": "utilize", "utilised": "utilized", "utilising": "utilizing",
+    "utilisation": "utilization", "utilisations": "utilizations",
     "capitalise": "capitalize", "capitalised": "capitalized",
     "amortise": "amortize", "amortised": "amortized", "amortisation": "amortization",
     "pseudonymise": "pseudonymize", "pseudonymised": "pseudonymized",


### PR DESCRIPTION
Two shipped defects found while reading all 172 skills. Both have mechanical fixes; `scripts/check-all.sh` passes.

## 1. Four `chief-*` skills have a corrupted `## Never` list

In each, a "Do not …" list was merged into a "Never …" list and the splice landed **inside a wrapped bullet**, orphaning its continuation onto an unrelated rule.

| file | bullet ends mid-sentence | continuation landed at |
|---|---|---|
| `security/chief-information-security-officer` | `:116` "…exist as documented," | `:120` |
| `corporate-strategy/chief-strategy-officer` | `:88` "…serves a thesis written" | `:91` |
| `customer-experience/chief-customer-officer` | `:76` "…Count the contacts" | `:79` |
| `data-analytics/chief-data-officer` | `:93` "…you will find out" | `:97` |

The CISO file rendered as:

```
- Do not fix another team's finding for them and leave the cause in place
  which is a different question from whether they work.
```

Each split bullet is reunited, and the two voices are ordered consistently — Never-voiced items first, Do-not-voiced after. The CISO file also stated one rule twice (`:117` and `:121`); the fuller wording is kept.

No wording is changed beyond rejoining sentences that were already there.

## 2. `check-us-english.py` missed `utilisation`

`scripts/check-us-english.py:57` listed `utilise`/`utilised`/`utilising` but not the noun form — though every sibling entry carries its `-ation` form (organisation, prioritisation, optimisation, realisation, minimisation, maximisation).

Three British spellings were shipping in `operations/capacity-and-demand-planning` while CI reported clean. Red → green:

```
before:      US English: 0 British spelling(s)      ← 3 were shipping
with entry:  capacity-and-demand-planning:35  'Utilisation' -> 'Utilization'
             capacity-and-demand-planning:46  'utilisation' -> 'utilization'
             capacity-and-demand-planning:57  'utilisation' -> 'utilization'
             US English: 3 British spelling(s)   exit=1
after --fix: US English: 0 British spelling(s)   exit=0
```

The prose was corrected by the script's own `--fix`, so that wording is yours, not mine.

## Verification

`scripts/check-all.sh` — all green: 172 skills valid, provenance clean, README / social card / org chart current, **273 skill references resolve**, manifests parse.

---

Seven further findings from the same read — including a `docs/USE-CASES.md` reference that ships in no plugin, and a description/body mismatch in `partnership-marketing` — are in a companion issue. Those are authorial calls rather than mechanical fixes, so I left them out of this PR.